### PR TITLE
Cleanup lua code

### DIFF
--- a/beam.lua
+++ b/beam.lua
@@ -2,9 +2,8 @@ require 'nn'
 require 'string'
 require 'nngraph'
 
-require 'models'
-require 'data'
-require 'util'
+dofile 'models.lua'
+dofile 'data.lua'
 
 path = require 'pl.path'
 stringx = require 'pl.stringx'

--- a/beam.lua
+++ b/beam.lua
@@ -1,682 +1,672 @@
 require 'nn'
 require 'string'
-require 'hdf5'
 require 'nngraph'
 
-require 'models.lua'
-require 'data.lua'
-require 'util.lua'
+require 'models'
+require 'data'
+require 'util'
 
-stringx = require('pl.stringx')
+path = require 'pl.path'
+stringx = require 'pl.stringx'
 
 cmd = torch.CmdLine()
 
 -- file location
 cmd:option('-model', 'seq2seq_lstm_attn.t7.', [[Path to model .t7 file]])
-cmd:option('-src_file', '',[[Source sequence to decode (one line per sequence)]])
+cmd:option('-src_file', '', [[Source sequence to decode (one line per sequence)]])
 cmd:option('-targ_file', '', [[True target sequence (optional)]])
-cmd:option('-output_file', 'pred.txt', [[Path to output the predictions (each line will be the
-                                       decoded sequence]])
+cmd:option('-output_file', 'pred.txt', [[Path to output the predictions (each line will be the decoded sequence]])
 cmd:option('-src_dict', 'data/demo.src.dict', [[Path to source vocabulary (*.src.dict file)]])
 cmd:option('-targ_dict', 'data/demo.targ.dict', [[Path to target vocabulary (*.targ.dict file)]])
-cmd:option('-char_dict', 'data/demo.char.dict', [[If using chars, path to character 
-                                                vocabulary (*.char.dict file)]])
+cmd:option('-char_dict', 'data/demo.char.dict', [[If using chars, path to character vocabulary (*.char.dict file)]])
 
 -- beam search options
 cmd:option('-beam', 5,[[Beam size]])
-cmd:option('-max_sent_l', 250, [[Maximum sentence length. If any sequences in srcfile are longer
-                               than this then it will error out]])
+cmd:option('-max_sent_l', 250, [[Maximum sentence length. If any sequences in srcfile are longer than this then it will error out]])
 cmd:option('-simple', 0, [[If = 1, output prediction is simply the first time the top of the beam
-                         ends with an end-of-sentence token. If = 0, the model considers all 
-                         hypotheses that have been generated so far that ends with end-of-sentence 
+                         ends with an end-of-sentence token. If = 0, the model considers all
+                         hypotheses that have been generated so far that ends with end-of-sentence
                          token and takes the highest scoring of all of them.]])
-cmd:option('-replace_unk', 0, [[Replace the generated UNK tokens with the source token that 
-                              had the highest attention weight. If srctarg_dict is provided, 
-                              it will lookup the identified source token and give the corresponding 
+cmd:option('-replace_unk', 0, [[Replace the generated UNK tokens with the source token that
+                              had the highest attention weight. If srctarg_dict is provided,
+                              it will lookup the identified source token and give the corresponding
                               target token. If it is not provided (or the identified source token
                               does not exist in the table) then it will copy the source token]])
-cmd:option('-srctarg_dict', 'data/en-de.dict', [[Path to source-target dictionary to replace UNK 
-                             tokens. See README.md for the format this file should be in]])
+cmd:option('-srctarg_dict', 'data/en-de.dict', [[Path to source-target dictionary to replace UNK
+                                               tokens. See README.md for the format this file should be in]])
 cmd:option('-score_gold', 1, [[If = 1, score the log likelihood of the gold as well]])
 cmd:option('-n_best', 1, [[If > 1, it will also output an n_best list of decoded sentences]])
-cmd:option('-gpuid',  -1, [[ID of the GPU to use (-1 = use CPU)]])
+cmd:option('-gpuid', -1, [[ID of the GPU to use (-1 = use CPU)]])
 cmd:option('-gpuid2', -1, [[Second GPU ID]])
-cmd:option('-cudnn', 0, [[If using character model, this should be = 1 if the character model
-                          was trained using cudnn]])
-opt = cmd:parse(arg)
+cmd:option('-cudnn', 0, [[If using character model, this should be = 1 if the character model was trained using cudnn]])
 
 function copy(orig)
-   local orig_type = type(orig)
-   local copy
-   if orig_type == 'table' then
-      copy = {}
-      for orig_key, orig_value in pairs(orig) do
-         copy[orig_key] = orig_value
-      end
-   else
-      copy = orig
-   end
-   return copy
+  local orig_type = type(orig)
+  local copy
+  if orig_type == 'table' then
+    copy = {}
+    for orig_key, orig_value in pairs(orig) do
+      copy[orig_key] = orig_value
+    end
+  else
+    copy = orig
+  end
+  return copy
 end
 
 local StateAll = torch.class("StateAll")
 
 function StateAll.initial(start)
-   return {start}
+  return {start}
 end
 
 function StateAll.advance(state, token)
-   local new_state = copy(state)
-   table.insert(new_state, token)
-   return new_state
+  local new_state = copy(state)
+  table.insert(new_state, token)
+  return new_state
 end
 
 function StateAll.disallow(out)
-   local bad = {1, 3} -- 1 is PAD, 3 is BOS
-   for j = 1, #bad do
-      out[bad[j]] = -1e9
-   end
+  local bad = {1, 3} -- 1 is PAD, 3 is BOS
+  for j = 1, #bad do
+    out[bad[j]] = -1e9
+  end
 end
 
 function StateAll.same(state1, state2)
-   for i = 2, #state1 do
-      if state1[i] ~= state2[i] then
-         return false
-      end
-   end
-   return true
+  for i = 2, #state1 do
+    if state1[i] ~= state2[i] then
+      return false
+    end
+  end
+  return true
 end
 
 function StateAll.next(state)
-   return state[#state]
+  return state[#state]
 end
 
 function StateAll.heuristic(state)
-   return 0
+  return 0
 end
 
 function StateAll.print(state)
-   for i = 1, #state do
-      io.write(state[i] .. " ")
-   end
-   print()
+  for i = 1, #state do
+    io.write(state[i] .. " ")
+  end
+  print()
 end
-
 
 -- Convert a flat index to a row-column tuple.
 function flat_to_rc(v, flat_index)
-   local row = math.floor((flat_index - 1) / v:size(2)) + 1
-   return row, (flat_index - 1) % v:size(2) + 1
+  local row = math.floor((flat_index - 1) / v:size(2)) + 1
+  return row, (flat_index - 1) % v:size(2) + 1
 end
 
 function generate_beam(model, initial, K, max_sent_l, source, gold)
-   --reset decoder initial states
-   if opt.gpuid >= 0 and opt.gpuid2 >= 0 then
-      cutorch.setDevice(opt.gpuid)
-   end
-   local n = max_sent_l
+  --reset decoder initial states
+  if opt.gpuid >= 0 and opt.gpuid2 >= 0 then
+    cutorch.setDevice(opt.gpuid)
+  end
+  local n = max_sent_l
   -- Backpointer table.
-   local prev_ks = torch.LongTensor(n, K):fill(1)
-   -- Current States.
-   local next_ys = torch.LongTensor(n, K):fill(1)
-   -- Current Scores.
-   local scores = torch.FloatTensor(n, K)
-   scores:zero()
-   local source_l = math.min(source:size(1), opt.max_sent_l)
-   local attn_argmax = {}   -- store attn weights
-   attn_argmax[1] = {}
+  local prev_ks = torch.LongTensor(n, K):fill(1)
+  -- Current States.
+  local next_ys = torch.LongTensor(n, K):fill(1)
+  -- Current Scores.
+  local scores = torch.FloatTensor(n, K)
+  scores:zero()
+  local source_l = math.min(source:size(1), opt.max_sent_l)
+  local attn_argmax = {} -- store attn weights
+  attn_argmax[1] = {}
 
-   local states = {} -- store predicted word idx
-   states[1] = {}
-   for k = 1, 1 do
-      table.insert(states[1], initial)
-      table.insert(attn_argmax[1], initial)
-      next_ys[1][k] = State.next(initial)
-   end
+  local states = {} -- store predicted word idx
+  states[1] = {}
+  for k = 1, 1 do
+    table.insert(states[1], initial)
+    table.insert(attn_argmax[1], initial)
+    next_ys[1][k] = State.next(initial)
+  end
 
-   local source_input
-   if model_opt.use_chars_enc == 1 then
-      source_input = source:view(source_l, 1, source:size(2)):contiguous()
-   else
-      source_input = source:view(source_l, 1)
-   end
+  local source_input
+  if model_opt.use_chars_enc == 1 then
+    source_input = source:view(source_l, 1, source:size(2)):contiguous()
+  else
+    source_input = source:view(source_l, 1)
+  end
 
-   local rnn_state_enc = {}
-   for i = 1, #init_fwd_enc do
-      table.insert(rnn_state_enc, init_fwd_enc[i]:zero())
-   end   
-   local context = context_proto[{{}, {1,source_l}}]:clone() -- 1 x source_l x rnn_size
-   
-   for t = 1, source_l do
+  local rnn_state_enc = {}
+  for i = 1, #init_fwd_enc do
+    table.insert(rnn_state_enc, init_fwd_enc[i]:zero())
+  end
+  local context = context_proto[{{}, {1,source_l}}]:clone() -- 1 x source_l x rnn_size
+
+  for t = 1, source_l do
+    local encoder_input = {source_input[t], table.unpack(rnn_state_enc)}
+    local out = model[1]:forward(encoder_input)
+    rnn_state_enc = out
+    context[{{},t}]:copy(out[#out])
+  end
+  rnn_state_dec = {}
+  for i = 1, #init_fwd_dec do
+    table.insert(rnn_state_dec, init_fwd_dec[i]:zero())
+  end
+
+  if model_opt.init_dec == 1 then
+    for L = 1, model_opt.num_layers do
+      rnn_state_dec[L*2-1+model_opt.input_feed]:copy(
+        rnn_state_enc[L*2-1]:expand(K, model_opt.rnn_size))
+      rnn_state_dec[L*2+model_opt.input_feed]:copy(
+        rnn_state_enc[L*2]:expand(K, model_opt.rnn_size))
+    end
+  end
+
+  if model_opt.brnn == 1 then
+    for i = 1, #rnn_state_enc do
+      rnn_state_enc[i]:zero()
+    end
+    for t = source_l, 1, -1 do
       local encoder_input = {source_input[t], table.unpack(rnn_state_enc)}
-      local out = model[1]:forward(encoder_input)
+      local out = model[4]:forward(encoder_input)
       rnn_state_enc = out
-      context[{{},t}]:copy(out[#out])
-   end
-   rnn_state_dec = {}
-   for i = 1, #init_fwd_dec do
-      table.insert(rnn_state_dec, init_fwd_dec[i]:zero())
-   end
-
-   if model_opt.init_dec == 1 then
+      context[{{},t}]:add(out[#out])
+    end
+    if model_opt.init_dec == 1 then
       for L = 1, model_opt.num_layers do
-	 rnn_state_dec[L*2-1+model_opt.input_feed]:copy(
-	    rnn_state_enc[L*2-1]:expand(K, model_opt.rnn_size))
-	 rnn_state_dec[L*2+model_opt.input_feed]:copy(
-	    rnn_state_enc[L*2]:expand(K, model_opt.rnn_size))
+        rnn_state_dec[L*2-1+model_opt.input_feed]:add(
+          rnn_state_enc[L*2-1]:expand(K, model_opt.rnn_size))
+        rnn_state_dec[L*2+model_opt.input_feed]:add(
+          rnn_state_enc[L*2]:expand(K, model_opt.rnn_size))
       end
-   end
-   
-   if model_opt.brnn == 1 then
-      for i = 1, #rnn_state_enc do
-	 rnn_state_enc[i]:zero()
-      end      
-      for t = source_l, 1, -1 do
-	 local encoder_input = {source_input[t], table.unpack(rnn_state_enc)}
-	 local out = model[4]:forward(encoder_input)
-	 rnn_state_enc = out
-	 context[{{},t}]:add(out[#out])
-      end
-      if model_opt.init_dec == 1 then
-	 for L = 1, model_opt.num_layers do
-	    rnn_state_dec[L*2-1+model_opt.input_feed]:add(
-	       rnn_state_enc[L*2-1]:expand(K, model_opt.rnn_size))
-	    rnn_state_dec[L*2+model_opt.input_feed]:add(
-	       rnn_state_enc[L*2]:expand(K, model_opt.rnn_size))	    
-	 end	 
-      end      
-   end
-   if opt.score_gold == 1 then
-      rnn_state_dec_gold = {}
-      for i = 1, #rnn_state_dec do
-	 table.insert(rnn_state_dec_gold, rnn_state_dec[i][{{1}}]:clone())
-      end      
-   end
-   
-   context = context:expand(K, source_l, model_opt.rnn_size)
-   
-   if opt.gpuid >= 0 and opt.gpuid2 >= 0 then
-      cutorch.setDevice(opt.gpuid2)
-      local context2 = context_proto2[{{1, K}, {1, source_l}}]
-      context2:copy(context)
-      context = context2
-   end
+    end
+  end
+  if opt.score_gold == 1 then
+    rnn_state_dec_gold = {}
+    for i = 1, #rnn_state_dec do
+      table.insert(rnn_state_dec_gold, rnn_state_dec[i][{{1}}]:clone())
+    end
+  end
 
-   out_float = torch.FloatTensor()
-   
-   local i = 1
-   local done = false
-   local max_score = -1e9
-   local found_eos = false
-   while (not done) and (i < n) do
-      i = i+1
-      states[i] = {}
-      attn_argmax[i] = {}
+  context = context:expand(K, source_l, model_opt.rnn_size)
+
+  if opt.gpuid >= 0 and opt.gpuid2 >= 0 then
+    cutorch.setDevice(opt.gpuid2)
+    local context2 = context_proto2[{{1, K}, {1, source_l}}]
+    context2:copy(context)
+    context = context2
+  end
+
+  out_float = torch.FloatTensor()
+
+  local i = 1
+  local done = false
+  local max_score = -1e9
+  local found_eos = false
+  while (not done) and (i < n) do
+    i = i+1
+    states[i] = {}
+    attn_argmax[i] = {}
+    local decoder_input1
+    if model_opt.use_chars_dec == 1 then
+      decoder_input1 = word2charidx_targ:index(1, next_ys:narrow(1,i-1,1):squeeze())
+    else
+      decoder_input1 = next_ys:narrow(1,i-1,1):squeeze()
+      if opt.beam == 1 then
+        decoder_input1 = torch.LongTensor({decoder_input1})
+      end
+    end
+    local decoder_input
+    if model_opt.attn == 1 then
+      decoder_input = {decoder_input1, context, table.unpack(rnn_state_dec)}
+    else
+      decoder_input = {decoder_input1, context[{{}, source_l}], table.unpack(rnn_state_dec)}
+    end
+    local out_decoder = model[2]:forward(decoder_input)
+    local out = model[3]:forward(out_decoder[#out_decoder]) -- K x vocab_size
+
+    rnn_state_dec = {} -- to be modified later
+    if model_opt.input_feed == 1 then
+      table.insert(rnn_state_dec, out_decoder[#out_decoder])
+    end
+    for j = 1, #out_decoder - 1 do
+      table.insert(rnn_state_dec, out_decoder[j])
+    end
+    out_float:resize(out:size()):copy(out)
+    for k = 1, K do
+      State.disallow(out_float:select(1, k))
+      out_float[k]:add(scores[i-1][k])
+    end
+    -- All the scores available.
+
+    local flat_out = out_float:view(-1)
+    if i == 2 then
+      flat_out = out_float[1] -- all outputs same for first batch
+    end
+
+    if model_opt.start_symbol == 1 then
+      decoder_softmax.output[{{},1}]:zero()
+      decoder_softmax.output[{{},source_l}]:zero()
+    end
+
+    for k = 1, K do
+      while true do
+        local score, index = flat_out:max(1)
+        local score = score[1]
+        local prev_k, y_i = flat_to_rc(out_float, index[1])
+        states[i][k] = State.advance(states[i-1][prev_k], y_i)
+        local diff = true
+        for k2 = 1, k-1 do
+          if State.same(states[i][k2], states[i][k]) then
+            diff = false
+          end
+        end
+
+        if i < 2 or diff then
+          if model_opt.attn == 1 then
+            max_attn, max_index = decoder_softmax.output[prev_k]:max(1)
+            attn_argmax[i][k] = State.advance(attn_argmax[i-1][prev_k],max_index[1])
+          end
+          prev_ks[i][k] = prev_k
+          next_ys[i][k] = y_i
+          scores[i][k] = score
+          flat_out[index[1]] = -1e9
+          break -- move on to next k
+        end
+        flat_out[index[1]] = -1e9
+      end
+    end
+    for j = 1, #rnn_state_dec do
+      rnn_state_dec[j]:copy(rnn_state_dec[j]:index(1, prev_ks[i]))
+    end
+    end_hyp = states[i][1]
+    end_score = scores[i][1]
+    if model_opt.attn == 1 then
+      end_attn_argmax = attn_argmax[i][1]
+    end
+    if end_hyp[#end_hyp] == END then
+      done = true
+      found_eos = true
+    else
+      for k = 1, K do
+        local possible_hyp = states[i][k]
+        if possible_hyp[#possible_hyp] == END then
+          found_eos = true
+          if scores[i][k] > max_score then
+            max_hyp = possible_hyp
+            max_score = scores[i][k]
+            if model_opt.attn == 1 then
+              max_attn_argmax = attn_argmax[i][k]
+            end
+          end
+        end
+      end
+    end
+  end
+  local gold_score = 0
+  if opt.score_gold == 1 then
+    rnn_state_dec = {}
+    for i = 1, #init_fwd_dec do
+      table.insert(rnn_state_dec, init_fwd_dec[i][{{1}}]:zero())
+    end
+    if model_opt.init_dec == 1 then
+      rnn_state_dec = rnn_state_dec_gold
+    end
+    local target_l = gold:size(1)
+    for t = 2, target_l do
       local decoder_input1
       if model_opt.use_chars_dec == 1 then
-	 decoder_input1 = word2charidx_targ:index(1, next_ys:narrow(1,i-1,1):squeeze())
+        decoder_input1 = word2charidx_targ:index(1, gold[{{t-1}}])
       else
-	 decoder_input1 = next_ys:narrow(1,i-1,1):squeeze()
-	 if opt.beam == 1 then
-	    decoder_input1 = torch.LongTensor({decoder_input1})
-	 end	
+        decoder_input1 = gold[{{t-1}}]
       end
       local decoder_input
       if model_opt.attn == 1 then
-	 decoder_input = {decoder_input1, context, table.unpack(rnn_state_dec)}
+        decoder_input = {decoder_input1, context[{{1}}], table.unpack(rnn_state_dec)}
       else
-	 decoder_input = {decoder_input1, context[{{}, source_l}], table.unpack(rnn_state_dec)}
-      end      
+        decoder_input = {decoder_input1, context[{{1}, source_l}], table.unpack(rnn_state_dec)}
+      end
       local out_decoder = model[2]:forward(decoder_input)
       local out = model[3]:forward(out_decoder[#out_decoder]) -- K x vocab_size
-      
       rnn_state_dec = {} -- to be modified later
       if model_opt.input_feed == 1 then
-	 table.insert(rnn_state_dec, out_decoder[#out_decoder])
-      end      
+        table.insert(rnn_state_dec, out_decoder[#out_decoder])
+      end
       for j = 1, #out_decoder - 1 do
-	 table.insert(rnn_state_dec, out_decoder[j])
+        table.insert(rnn_state_dec, out_decoder[j])
       end
-      out_float:resize(out:size()):copy(out)
-      for k = 1, K do
-	 State.disallow(out_float:select(1, k))
-	 out_float[k]:add(scores[i-1][k])
-      end
-      -- All the scores available.
+      gold_score = gold_score + out[1][gold[t]]
+    end
+  end
+  if opt.simple == 1 or end_score > max_score or not found_eos then
+    max_hyp = end_hyp
+    max_score = end_score
+    max_attn_argmax = end_attn_argmax
+  end
 
-       local flat_out = out_float:view(-1)
-       if i == 2 then
-          flat_out = out_float[1] -- all outputs same for first batch
-       end
-
-       if model_opt.start_symbol == 1 then
-	  decoder_softmax.output[{{},1}]:zero()
-	  decoder_softmax.output[{{},source_l}]:zero()
-       end
-       
-       for k = 1, K do
-          while true do
-             local score, index = flat_out:max(1)
-             local score = score[1]
-             local prev_k, y_i = flat_to_rc(out_float, index[1])
-             states[i][k] = State.advance(states[i-1][prev_k], y_i)
-             local diff = true
-             for k2 = 1, k-1 do
-                if State.same(states[i][k2], states[i][k]) then
-                   diff = false
-                end
-             end
-	     
-             if i < 2 or diff then
-		if model_opt.attn == 1 then
-		   max_attn, max_index = decoder_softmax.output[prev_k]:max(1)
-		   attn_argmax[i][k] = State.advance(attn_argmax[i-1][prev_k],max_index[1])         
-		end		
-	        prev_ks[i][k] = prev_k
-                next_ys[i][k] = y_i
-                scores[i][k] = score
-                flat_out[index[1]] = -1e9
-                break -- move on to next k 
-             end
-             flat_out[index[1]] = -1e9
-          end
-       end
-       for j = 1, #rnn_state_dec do
-	  rnn_state_dec[j]:copy(rnn_state_dec[j]:index(1, prev_ks[i]))
-       end
-       end_hyp = states[i][1]
-       end_score = scores[i][1]
-       if model_opt.attn == 1 then
-	  end_attn_argmax = attn_argmax[i][1]
-       end       
-       if end_hyp[#end_hyp] == END then
-	  done = true
-	  found_eos = true
-       else
-	  for k = 1, K do
-	     local possible_hyp = states[i][k]
-	     if possible_hyp[#possible_hyp] == END then
-		found_eos = true
-		if scores[i][k] > max_score then
-		   max_hyp = possible_hyp
-		   max_score = scores[i][k]
-		   if model_opt.attn == 1 then
-		      max_attn_argmax = attn_argmax[i][k]
-		   end		   
-		end
-	     end	     
-	  end	  
-       end       
-   end
-   local gold_score = 0
-   if opt.score_gold == 1 then
-      rnn_state_dec = {}
-      for i = 1, #init_fwd_dec do
-	 table.insert(rnn_state_dec, init_fwd_dec[i][{{1}}]:zero())
-      end
-      if model_opt.init_dec == 1 then
-	 rnn_state_dec = rnn_state_dec_gold
-      end
-      local target_l = gold:size(1) 
-      for t = 2, target_l do
-	 local decoder_input1
-	 if model_opt.use_chars_dec == 1 then
-	    decoder_input1 = word2charidx_targ:index(1, gold[{{t-1}}])
-	 else
-	    decoder_input1 = gold[{{t-1}}]
-	 end
-	 local decoder_input
-	 if model_opt.attn == 1 then
-	    decoder_input = {decoder_input1, context[{{1}}], table.unpack(rnn_state_dec)}
-	 else
-	    decoder_input = {decoder_input1, context[{{1}, source_l}], table.unpack(rnn_state_dec)}
-	 end      	 
-	 local out_decoder = model[2]:forward(decoder_input)
-	 local out = model[3]:forward(out_decoder[#out_decoder]) -- K x vocab_size
-	 rnn_state_dec = {} -- to be modified later
-	 if model_opt.input_feed == 1 then
-	    table.insert(rnn_state_dec, out_decoder[#out_decoder])
-	 end	 
-	 for j = 1, #out_decoder - 1 do
-	    table.insert(rnn_state_dec, out_decoder[j])
-	 end
-	 gold_score = gold_score + out[1][gold[t]]
-
-      end      
-   end
-   if opt.simple == 1 or end_score > max_score or not found_eos then
-      max_hyp = end_hyp
-      max_score = end_score
-      max_attn_argmax = end_attn_argmax
-   end
-
-   return max_hyp, max_score, max_attn_argmax, gold_score, states[i], scores[i], attn_argmax[i]
+  return max_hyp, max_score, max_attn_argmax, gold_score, states[i], scores[i], attn_argmax[i]
 end
 
-function idx2key(file)   
-   local f = io.open(file,'r')
-   local t = {}
-   for line in f:lines() do
-      local c = {}
-      for w in line:gmatch'([^%s]+)' do
-	 table.insert(c, w)
-      end
-      t[tonumber(c[2])] = c[1]
-   end   
-   return t
+function idx2key(file)
+  local f = io.open(file,'r')
+  local t = {}
+  for line in f:lines() do
+    local c = {}
+    for w in line:gmatch'([^%s]+)' do
+      table.insert(c, w)
+    end
+    t[tonumber(c[2])] = c[1]
+  end
+  return t
 end
 
 function flip_table(u)
-   local t = {}
-   for key, value in pairs(u) do
-      t[value] = key
-   end
-   return t   
+  local t = {}
+  for key, value in pairs(u) do
+    t[value] = key
+  end
+  return t
 end
 
-
 function get_layer(layer)
-   if layer.name ~= nil then
-      if layer.name == 'decoder_attn' then
-	 decoder_attn = layer
-      elseif layer.name:sub(1,3) == 'hop' then
-	 hop_attn = layer
-      elseif layer.name:sub(1,7) == 'softmax' then
-	 table.insert(softmax_layers, layer)
-      elseif layer.name == 'word_vecs_enc' then
-	 word_vecs_enc = layer
-      elseif layer.name == 'word_vecs_dec' then
-	 word_vecs_dec = layer
-      end       
-   end
+  if layer.name ~= nil then
+    if layer.name == 'decoder_attn' then
+      decoder_attn = layer
+    elseif layer.name:sub(1,3) == 'hop' then
+      hop_attn = layer
+    elseif layer.name:sub(1,7) == 'softmax' then
+      table.insert(softmax_layers, layer)
+    elseif layer.name == 'word_vecs_enc' then
+      word_vecs_enc = layer
+    elseif layer.name == 'word_vecs_dec' then
+      word_vecs_dec = layer
+    end
+  end
 end
 
 function sent2wordidx(sent, word2idx, start_symbol)
-   local t = {}
-   local u = {}
-   if start_symbol == 1 then
-      table.insert(t, START)
-      table.insert(u, START_WORD)
-   end
-   
-   for word in sent:gmatch'([^%s]+)' do
-      local idx = word2idx[word] or UNK 
-      table.insert(t, idx)
-      table.insert(u, word)
-   end
-   if start_symbol == 1 then
-      table.insert(t, END)
-      table.insert(u, END_WORD)
-   end   
-   return torch.LongTensor(t), u
+  local t = {}
+  local u = {}
+  if start_symbol == 1 then
+    table.insert(t, START)
+    table.insert(u, START_WORD)
+  end
+
+  for word in sent:gmatch'([^%s]+)' do
+    local idx = word2idx[word] or UNK
+    table.insert(t, idx)
+    table.insert(u, word)
+  end
+  if start_symbol == 1 then
+    table.insert(t, END)
+    table.insert(u, END_WORD)
+  end
+  return torch.LongTensor(t), u
 end
 
 function sent2charidx(sent, char2idx, max_word_l, start_symbol)
-   local words = {}
-   if start_symbol == 1 then
-      table.insert(words, START_WORD)
-   end   
-   for word in sent:gmatch'([^%s]+)' do
-      table.insert(words, word)
-   end
-   if start_symbol == 1 then
-      table.insert(words, END_WORD)
-   end   
-   local chars = torch.ones(#words, max_word_l)
-   for i = 1, #words do
-      chars[i] = word2charidx(words[i], char2idx, max_word_l, chars[i])
-   end
-   return chars, words
+  local words = {}
+  if start_symbol == 1 then
+    table.insert(words, START_WORD)
+  end
+  for word in sent:gmatch'([^%s]+)' do
+    table.insert(words, word)
+  end
+  if start_symbol == 1 then
+    table.insert(words, END_WORD)
+  end
+  local chars = torch.ones(#words, max_word_l)
+  for i = 1, #words do
+    chars[i] = word2charidx(words[i], char2idx, max_word_l, chars[i])
+  end
+  return chars, words
 end
 
 function word2charidx(word, char2idx, max_word_l, t)
-   t[1] = START
-   local i = 2
-   for _, char in utf8.next, word do
-      char = utf8.char(char)
-      local char_idx = char2idx[char] or UNK
-      t[i] = char_idx
-      i = i+1
-      if i >= max_word_l then
-	 t[i] = END
-	 break
-      end
-   end
-   if i < max_word_l then
+  t[1] = START
+  local i = 2
+  for _, char in utf8.next, word do
+    char = utf8.char(char)
+    local char_idx = char2idx[char] or UNK
+    t[i] = char_idx
+    i = i+1
+    if i >= max_word_l then
       t[i] = END
-   end
-   return t
+      break
+    end
+  end
+  if i < max_word_l then
+    t[i] = END
+  end
+  return t
 end
 
 function wordidx2sent(sent, idx2word, source_str, attn, skip_end)
-   local t = {}
-   local start_i, end_i
-   skip_end = skip_start_end or true
-   if skip_end then
-      end_i = #sent-1
-   else
-      end_i = #sent
-   end   
-   for i = 2, end_i do -- skip START and END
-      if sent[i] == UNK then
-	 if opt.replace_unk == 1 then
-	    local s = source_str[attn[i]]
-	    if phrase_table[s] ~= nil then
-	       print(s .. ':' ..phrase_table[s])
-	    end	    
-	    local r = phrase_table[s] or s
-	    table.insert(t, r)	    
-	 else
-	    table.insert(t, idx2word[sent[i]])
-	 end	 
+  local t = {}
+  local start_i, end_i
+  skip_end = skip_start_end or true
+  if skip_end then
+    end_i = #sent-1
+  else
+    end_i = #sent
+  end
+  for i = 2, end_i do -- skip START and END
+    if sent[i] == UNK then
+      if opt.replace_unk == 1 then
+        local s = source_str[attn[i]]
+        if phrase_table[s] ~= nil then
+          print(s .. ':' ..phrase_table[s])
+        end
+        local r = phrase_table[s] or s
+        table.insert(t, r)
       else
-	 table.insert(t, idx2word[sent[i]])	 
-      end           
-   end
-   return table.concat(t, ' ')
+        table.insert(t, idx2word[sent[i]])
+      end
+    else
+      table.insert(t, idx2word[sent[i]])
+    end
+  end
+  return table.concat(t, ' ')
 end
 
 function clean_sent(sent)
-   local s = stringx.replace(sent, UNK_WORD, '')
-   s = stringx.replace(s, START_WORD, '')
-   s = stringx.replace(s, END_WORD, '')
-   s = stringx.replace(s, START_CHAR, '')
-   s = stringx.replace(s, END_CHAR, '')
-   return s
+  local s = stringx.replace(sent, UNK_WORD, '')
+  s = stringx.replace(s, START_WORD, '')
+  s = stringx.replace(s, END_WORD, '')
+  s = stringx.replace(s, START_CHAR, '')
+  s = stringx.replace(s, END_CHAR, '')
+  return s
 end
 
 function strip(s)
-   return s:gsub("^%s+",""):gsub("%s+$","")
+  return s:gsub("^%s+",""):gsub("%s+$","")
 end
 
 function main()
-   -- some globals
-   PAD = 1; UNK = 2; START = 3; END = 4
-   PAD_WORD = '<blank>'; UNK_WORD = '<unk>'; START_WORD = '<s>'; END_WORD = '</s>'
-   START_CHAR = '{'; END_CHAR = '}'
-   MAX_SENT_L = opt.max_sent_l
-   assert(path.exists(opt.src_file), 'src_file does not exist')
-   assert(path.exists(opt.model), 'model does not exist')
-   
-   -- parse input params
-   opt = cmd:parse(arg)
-   if opt.gpuid >= 0 then
-      require 'cutorch'
-      require 'cunn'
-      if opt.cudnn == 1 then
-	 require 'cudnn'
-      end      
-   end      
-   print('loading ' .. opt.model .. '...')
-   checkpoint = torch.load(opt.model)
-   print('done!')
+  -- parse input params
+  opt = cmd:parse(arg)
 
-   if opt.replace_unk == 1 then
-      phrase_table = {}
-      if path.exists(opt.srctarg_dict) then
-	 local f = io.open(opt.srctarg_dict,'r')
-	 for line in f:lines() do
-	    local c = line:split("|||")
-	    phrase_table[strip(c[1])] = c[2]
-	 end
-      end      
-   end
+  -- some globals
+  PAD = 1; UNK = 2; START = 3; END = 4
+  PAD_WORD = '<blank>'; UNK_WORD = '<unk>'; START_WORD = '<s>'; END_WORD = '</s>'
+  START_CHAR = '{'; END_CHAR = '}'
+  MAX_SENT_L = opt.max_sent_l
+  assert(path.exists(opt.src_file), 'src_file does not exist')
+  assert(path.exists(opt.model), 'model does not exist')
 
+  if opt.gpuid >= 0 then
+    require 'cutorch'
+    require 'cunn'
+    if opt.cudnn == 1 then
+      require 'cudnn'
+    end
+  end
+  print('loading ' .. opt.model .. '...')
+  checkpoint = torch.load(opt.model)
+  print('done!')
 
-   -- load model and word2idx/idx2word dictionaries
-   model, model_opt = checkpoint[1], checkpoint[2]  
-   for i = 1, #model do
-      model[i]:evaluate()
-   end
-   -- for backward compatibility
-   model_opt.brnn = model_opt.brnn or 0
-   model_opt.input_feed = model_opt.input_feed or 1
-   model_opt.attn = model_opt.attn or 1
-   
-   idx2word_src = idx2key(opt.src_dict)
-   word2idx_src = flip_table(idx2word_src)
-   idx2word_targ = idx2key(opt.targ_dict)
-   word2idx_targ = flip_table(idx2word_targ)
-   
-   -- load character dictionaries if needed
-   if model_opt.use_chars_enc == 1 or model_opt.use_chars_dec == 1 then
-      utf8 = require 'lua-utf8'      
-      char2idx = flip_table(idx2key(opt.char_dict))
-      model[1]:apply(get_layer)
-   end
-   if model_opt.use_chars_dec == 1 then
-      word2charidx_targ = torch.LongTensor(#idx2word_targ, model_opt.max_word_l):fill(PAD)
-      for i = 1, #idx2word_targ do
-	 word2charidx_targ[i] = word2charidx(idx2word_targ[i], char2idx,
-					     model_opt.max_word_l, word2charidx_targ[i])
-      end      
-   end  
-   -- load gold labels if it exists
-   if path.exists(opt.targ_file) then
-      print('loading GOLD labels at ' .. opt.targ_file)
-      gold = {}
-      local file = io.open(opt.targ_file, 'r')
-      for line in file:lines() do
-	 table.insert(gold, line)
+  if opt.replace_unk == 1 then
+    phrase_table = {}
+    if path.exists(opt.srctarg_dict) then
+      local f = io.open(opt.srctarg_dict,'r')
+      for line in f:lines() do
+        local c = line:split("|||")
+        phrase_table[strip(c[1])] = c[2]
       end
-   else
-      opt.score_gold = 0
-   end
+    end
+  end
 
-   if opt.gpuid >= 0 then
-      cutorch.setDevice(opt.gpuid)
-      for i = 1, #model do
-	 if opt.gpuid2 >= 0 then
-	    if i == 1 or i == 4 then
-	       cutorch.setDevice(opt.gpuid)
-	    else
-	       cutorch.setDevice(opt.gpuid2)
-	    end
-	 end	 	       
-	 model[i]:double():cuda()
-	 model[i]:evaluate()
-      end
-   end
+  -- load model and word2idx/idx2word dictionaries
+  model, model_opt = checkpoint[1], checkpoint[2]
+  for i = 1, #model do
+    model[i]:evaluate()
+  end
+  -- for backward compatibility
+  model_opt.brnn = model_opt.brnn or 0
+  model_opt.input_feed = model_opt.input_feed or 1
+  model_opt.attn = model_opt.attn or 1
 
-   softmax_layers = {}
-   model[2]:apply(get_layer)
-   if model_opt.attn == 1 then
-      decoder_attn:apply(get_layer)
-      decoder_softmax = softmax_layers[1]
-      attn_layer = torch.zeros(opt.beam, MAX_SENT_L)      
-   end
-   
-   
-   context_proto = torch.zeros(1, MAX_SENT_L, model_opt.rnn_size)
-   local h_init_dec = torch.zeros(opt.beam, model_opt.rnn_size)
-   local h_init_enc = torch.zeros(1, model_opt.rnn_size) 
-   if opt.gpuid >= 0 then
-      h_init_enc = h_init_enc:cuda()      
-      h_init_dec = h_init_dec:cuda()
-      cutorch.setDevice(opt.gpuid)
+  idx2word_src = idx2key(opt.src_dict)
+  word2idx_src = flip_table(idx2word_src)
+  idx2word_targ = idx2key(opt.targ_dict)
+  word2idx_targ = flip_table(idx2word_targ)
+
+  -- load character dictionaries if needed
+  if model_opt.use_chars_enc == 1 or model_opt.use_chars_dec == 1 then
+    utf8 = require 'lua-utf8'
+    char2idx = flip_table(idx2key(opt.char_dict))
+    model[1]:apply(get_layer)
+  end
+  if model_opt.use_chars_dec == 1 then
+    word2charidx_targ = torch.LongTensor(#idx2word_targ, model_opt.max_word_l):fill(PAD)
+    for i = 1, #idx2word_targ do
+      word2charidx_targ[i] = word2charidx(idx2word_targ[i], char2idx,
+        model_opt.max_word_l, word2charidx_targ[i])
+    end
+  end
+  -- load gold labels if it exists
+  if path.exists(opt.targ_file) then
+    print('loading GOLD labels at ' .. opt.targ_file)
+    gold = {}
+    local file = io.open(opt.targ_file, 'r')
+    for line in file:lines() do
+      table.insert(gold, line)
+    end
+  else
+    opt.score_gold = 0
+  end
+
+  if opt.gpuid >= 0 then
+    cutorch.setDevice(opt.gpuid)
+    for i = 1, #model do
       if opt.gpuid2 >= 0 then
-	 cutorch.setDevice(opt.gpuid)
-	 context_proto = context_proto:cuda()	 
-	 cutorch.setDevice(opt.gpuid2)
-	 context_proto2 = torch.zeros(opt.beam, MAX_SENT_L, model_opt.rnn_size):cuda()
-      else
-	 context_proto = context_proto:cuda()
+        if i == 1 or i == 4 then
+          cutorch.setDevice(opt.gpuid)
+        else
+          cutorch.setDevice(opt.gpuid2)
+        end
       end
-      if model_opt.attn == 1 then
-	 attn_layer = attn_layer:cuda()
-      end      
-   end
-   init_fwd_enc = {}
-   init_fwd_dec = {} -- initial context
-   if model_opt.input_feed == 1 then
-      table.insert(init_fwd_dec, h_init_dec:clone())
-   end
-   
-   for L = 1, model_opt.num_layers do
-      table.insert(init_fwd_enc, h_init_enc:clone())
-      table.insert(init_fwd_enc, h_init_enc:clone())
-      table.insert(init_fwd_dec, h_init_dec:clone()) -- memory cell
-      table.insert(init_fwd_dec, h_init_dec:clone()) -- hidden state      
-   end      
-     
-   pred_score_total = 0
-   gold_score_total = 0
-   pred_words_total = 0
-   gold_words_total = 0
-   
-   State = StateAll
-   local sent_id = 0
-   pred_sents = {}
-   local file = io.open(opt.src_file, "r")
-   local out_file = io.open(opt.output_file,'w')   
-   for line in file:lines() do
-      sent_id = sent_id + 1
-      line = clean_sent(line)      
-      print('SENT ' .. sent_id .. ': ' ..line)
-      local source, source_str
-      if model_opt.use_chars_enc == 0 then
-	 source, source_str = sent2wordidx(line, word2idx_src, model_opt.start_symbol)
-      else
-	 source, source_str = sent2charidx(line, char2idx, model_opt.max_word_l, model_opt.start_symbol)
-      end
+      model[i]:double():cuda()
+      model[i]:evaluate()
+    end
+  end
+
+  softmax_layers = {}
+  model[2]:apply(get_layer)
+  if model_opt.attn == 1 then
+    decoder_attn:apply(get_layer)
+    decoder_softmax = softmax_layers[1]
+    attn_layer = torch.zeros(opt.beam, MAX_SENT_L)
+  end
+
+  context_proto = torch.zeros(1, MAX_SENT_L, model_opt.rnn_size)
+  local h_init_dec = torch.zeros(opt.beam, model_opt.rnn_size)
+  local h_init_enc = torch.zeros(1, model_opt.rnn_size)
+  if opt.gpuid >= 0 then
+    h_init_enc = h_init_enc:cuda()
+    h_init_dec = h_init_dec:cuda()
+    cutorch.setDevice(opt.gpuid)
+    if opt.gpuid2 >= 0 then
+      cutorch.setDevice(opt.gpuid)
+      context_proto = context_proto:cuda()
+      cutorch.setDevice(opt.gpuid2)
+      context_proto2 = torch.zeros(opt.beam, MAX_SENT_L, model_opt.rnn_size):cuda()
+    else
+      context_proto = context_proto:cuda()
+    end
+    if model_opt.attn == 1 then
+      attn_layer = attn_layer:cuda()
+    end
+  end
+  init_fwd_enc = {}
+  init_fwd_dec = {} -- initial context
+  if model_opt.input_feed == 1 then
+    table.insert(init_fwd_dec, h_init_dec:clone())
+  end
+
+  for L = 1, model_opt.num_layers do
+    table.insert(init_fwd_enc, h_init_enc:clone())
+    table.insert(init_fwd_enc, h_init_enc:clone())
+    table.insert(init_fwd_dec, h_init_dec:clone()) -- memory cell
+    table.insert(init_fwd_dec, h_init_dec:clone()) -- hidden state
+  end
+
+  pred_score_total = 0
+  gold_score_total = 0
+  pred_words_total = 0
+  gold_words_total = 0
+
+  State = StateAll
+  local sent_id = 0
+  pred_sents = {}
+  local file = io.open(opt.src_file, "r")
+  local out_file = io.open(opt.output_file,'w')
+  for line in file:lines() do
+    sent_id = sent_id + 1
+    line = clean_sent(line)
+    print('SENT ' .. sent_id .. ': ' ..line)
+    local source, source_str
+    if model_opt.use_chars_enc == 0 then
+      source, source_str = sent2wordidx(line, word2idx_src, model_opt.start_symbol)
+    else
+      source, source_str = sent2charidx(line, char2idx, model_opt.max_word_l, model_opt.start_symbol)
+    end
+    if opt.score_gold == 1 then
+      target, target_str = sent2wordidx(gold[sent_id], word2idx_targ, 1)
+    end
+    state = State.initial(START)
+    pred, pred_score, attn, gold_score, all_sents, all_scores, all_attn = generate_beam(model,
+      state, opt.beam, MAX_SENT_L, source, target)
+    pred_score_total = pred_score_total + pred_score
+    pred_words_total = pred_words_total + #pred - 1
+    pred_sent = wordidx2sent(pred, idx2word_targ, source_str, attn, true)
+    out_file:write(pred_sent .. '\n')
+    print('PRED ' .. sent_id .. ': ' .. pred_sent)
+    if gold ~= nil then
+      print('GOLD ' .. sent_id .. ': ' .. gold[sent_id])
       if opt.score_gold == 1 then
-	 target, target_str = sent2wordidx(gold[sent_id], word2idx_targ, 1)
+        print(string.format("PRED SCORE: %.4f, GOLD SCORE: %.4f", pred_score, gold_score))
+        gold_score_total = gold_score_total + gold_score
+        gold_words_total = gold_words_total + target:size(1) - 1
       end
-      state = State.initial(START)
-      pred, pred_score, attn, gold_score, all_sents, all_scores, all_attn = generate_beam(model,
-  		state, opt.beam, MAX_SENT_L, source, target)
-      pred_score_total = pred_score_total + pred_score
-      pred_words_total = pred_words_total + #pred - 1
-      pred_sent = wordidx2sent(pred, idx2word_targ, source_str, attn, true)
-      out_file:write(pred_sent .. '\n')      
-      print('PRED ' .. sent_id .. ': ' .. pred_sent)
-      if gold ~= nil then
-	 print('GOLD ' .. sent_id .. ': ' .. gold[sent_id])
-	 if opt.score_gold == 1 then
-	    print(string.format("PRED SCORE: %.4f, GOLD SCORE: %.4f", pred_score, gold_score))
-	    gold_score_total = gold_score_total + gold_score
-	    gold_words_total = gold_words_total + target:size(1) - 1	 	    
-	 end
+    end
+    if opt.n_best > 1 then
+      for n = 1, opt.n_best do
+        pred_sent_n = wordidx2sent(all_sents[n], idx2word_targ, source_str, all_attn[n], false)
+        local out_n = string.format("%d ||| %s ||| %.4f", n, pred_sent_n, all_scores[n])
+        print(out_n)
+        out_file:write(out_n .. '\n')
       end
-      if opt.n_best > 1 then
-	 for n = 1, opt.n_best do
-	    pred_sent_n = wordidx2sent(all_sents[n], idx2word_targ, source_str, all_attn[n], false)
-	    local out_n = string.format("%d ||| %s ||| %.4f", n, pred_sent_n, all_scores[n])
-	    print(out_n)
-	    out_file:write(out_n .. '\n')
-	 end	 
-      end
-      
-      print('')
-   end
-   print(string.format("PRED AVG SCORE: %.4f, PRED PPL: %.4f", pred_score_total / pred_words_total,
-		       math.exp(-pred_score_total/pred_words_total)))
-   if opt.score_gold == 1 then      
-      print(string.format("GOLD AVG SCORE: %.4f, GOLD PPL: %.4f",
-			  gold_score_total / gold_words_total,
-			  math.exp(-gold_score_total/gold_words_total)))
-   end
-   out_file:close()
+    end
+
+    print('')
+  end
+  print(string.format("PRED AVG SCORE: %.4f, PRED PPL: %.4f", pred_score_total / pred_words_total,
+      math.exp(-pred_score_total/pred_words_total)))
+  if opt.score_gold == 1 then
+    print(string.format("GOLD AVG SCORE: %.4f, GOLD PPL: %.4f",
+        gold_score_total / gold_words_total,
+        math.exp(-gold_score_total/gold_words_total)))
+  end
+  out_file:close()
 end
 main()
-

--- a/convert_to_cpu.lua
+++ b/convert_to_cpu.lua
@@ -2,33 +2,34 @@ require 'nn'
 require 'string'
 require 'hdf5'
 require 'nngraph'
-
-require 'models.lua'
-require 'data.lua'
-require 'util.lua'
 require 'cunn'
 require 'cutorch'
 
+require 'models'
+require 'data'
+require 'util'
+
 cmd = torch.CmdLine()
+
 -- file location
 cmd:option('-gpu_file', 'gpu_model.t7','gpu model file')
-cmd:option('-cpu_file','cpu_model.t7', 'cpu output file')
+cmd:option('-cpu_file', 'cpu_model.t7', 'cpu output file')
 cmd:option('-gpuid', 2, 'which gpuid to use')
 opt = cmd:parse(arg)
 
 function main()
-   print('loading gpu model ' .. opt.gpu_file)
-   checkpoint = torch.load(opt.gpu_file)
-   model, model_opt = checkpoint[1], checkpoint[2]
-   if model_opt.cudnn == 1 then
-      require 'cudnn'
-   end   
-   cutorch.setDevice(opt.gpuid)
-   for i = 1, #model do
-      model[i]:double()
-   end   
-   print('saving cpu model to ' .. opt.cpu_file)
-   torch.save(opt.cpu_file, {model, model_opt})
+  print('loading gpu model ' .. opt.gpu_file)
+  checkpoint = torch.load(opt.gpu_file)
+  model, model_opt = checkpoint[1], checkpoint[2]
+  if model_opt.cudnn == 1 then
+    require 'cudnn'
+  end
+  cutorch.setDevice(opt.gpuid)
+  for i = 1, #model do
+    model[i]:double()
+  end
+  print('saving cpu model to ' .. opt.cpu_file)
+  torch.save(opt.cpu_file, {model, model_opt})
 end
 main()
 

--- a/convert_to_cpu.lua
+++ b/convert_to_cpu.lua
@@ -5,9 +5,8 @@ require 'nngraph'
 require 'cunn'
 require 'cutorch'
 
-require 'models'
-require 'data'
-require 'util'
+dofile 'models.lua'
+dofile 'data.lua'
 
 cmd = torch.CmdLine()
 

--- a/data.lua
+++ b/data.lua
@@ -5,116 +5,116 @@
 local data = torch.class("data")
 
 function data:__init(opt, data_file)
-   local f = hdf5.open(data_file, 'r')
-   
-   self.source  = f:read('source'):all()
-   self.target  = f:read('target'):all()   
-   self.target_output = f:read('target_output'):all()
-   self.target_l = f:read('target_l'):all() --max target length each batch
-   self.target_l_all = f:read('target_l_all'):all()
-   self.target_l_all:add(-1)
-   self.batch_l = f:read('batch_l'):all()
-   self.source_l = f:read('batch_w'):all() --max source length each batch
-   if opt.start_symbol == 0 then
-      self.source_l:add(-2)
-      self.source = self.source[{{},{2, self.source:size(2)-1}}]
-   end   
-   self.batch_idx = f:read('batch_idx'):all()
-   
-   self.target_size = f:read('target_size'):all()[1]
-   self.source_size = f:read('source_size'):all()[1]
-   self.target_nonzeros = f:read('target_nonzeros'):all()
-  
-   if opt.use_chars_enc == 1 then
-      self.source_char = f:read('source_char'):all()
-      self.char_size = f:read('char_size'):all()[1]
-      self.char_length = self.source_char:size(3)
-      if opt.start_symbol == 0 then
-	 self.source_char = self.source_char[{{}, {2, self.source_char:size(2)-1}}]
-      end      
-   end
-   
-   if opt.use_chars_dec == 1 then
-      self.target_char = f:read('target_char'):all()
-      self.char_size = f:read('char_size'):all()[1]
-      self.char_length = self.target_char:size(3)      
-   end   
-   
-   self.length = self.batch_l:size(1)
-   self.seq_length = self.target:size(2) 
-   self.batches = {}
-   local max_source_l = self.source_l:max()   
-   local source_l_rev = torch.ones(max_source_l):long()
-   for i = 1, max_source_l do
-      source_l_rev[i] = max_source_l - i + 1
-   end   
-   for i = 1, self.length do
-      local source_i, target_i
-      local target_output_i = self.target_output:sub(self.batch_idx[i],self.batch_idx[i]
-							+self.batch_l[i]-1, 1, self.target_l[i])
-      local target_l_i = self.target_l_all:sub(self.batch_idx[i],
-					       self.batch_idx[i]+self.batch_l[i]-1)
-      if opt.use_chars_enc == 1 then
-	 source_i = self.source_char:sub(self.batch_idx[i],
-					      self.batch_idx[i] + self.batch_l[i]-1, 1,
-					      self.source_l[i]):transpose(1,2):contiguous()
-      else
-	 source_i =  self.source:sub(self.batch_idx[i], self.batch_idx[i]+self.batch_l[i]-1,
-				     1, self.source_l[i]):transpose(1,2)
-      end
-      if opt.reverse_src == 1 then
-	 source_i = source_i:index(1, source_l_rev[{{max_source_l-self.source_l[i]+1,
-						     max_source_l}}])
-      end      
+  local f = hdf5.open(data_file, 'r')
 
-      if opt.use_chars_dec == 1 then
-	 target_i = self.target_char:sub(self.batch_idx[i],
-					      self.batch_idx[i] + self.batch_l[i]-1, 1,
-					      self.target_l[i]):transpose(1,2):contiguous()
-      else
-	 target_i = self.target:sub(self.batch_idx[i], self.batch_idx[i]+self.batch_l[i]-1,
-				    1, self.target_l[i]):transpose(1,2)
-      end
-      table.insert(self.batches,  {target_i,
-				  target_output_i:transpose(1,2),
-				  self.target_nonzeros[i], 
-				  source_i,
-				  self.batch_l[i],
-				  self.target_l[i],
-				  self.source_l[i],
-				  target_l_i})
-   end
+  self.source = f:read('source'):all()
+  self.target = f:read('target'):all()
+  self.target_output = f:read('target_output'):all()
+  self.target_l = f:read('target_l'):all() --max target length each batch
+  self.target_l_all = f:read('target_l_all'):all()
+  self.target_l_all:add(-1)
+  self.batch_l = f:read('batch_l'):all()
+  self.source_l = f:read('batch_w'):all() --max source length each batch
+  if opt.start_symbol == 0 then
+    self.source_l:add(-2)
+    self.source = self.source[{{},{2, self.source:size(2)-1}}]
+  end
+  self.batch_idx = f:read('batch_idx'):all()
+
+  self.target_size = f:read('target_size'):all()[1]
+  self.source_size = f:read('source_size'):all()[1]
+  self.target_nonzeros = f:read('target_nonzeros'):all()
+
+  if opt.use_chars_enc == 1 then
+    self.source_char = f:read('source_char'):all()
+    self.char_size = f:read('char_size'):all()[1]
+    self.char_length = self.source_char:size(3)
+    if opt.start_symbol == 0 then
+      self.source_char = self.source_char[{{}, {2, self.source_char:size(2)-1}}]
+    end
+  end
+
+  if opt.use_chars_dec == 1 then
+    self.target_char = f:read('target_char'):all()
+    self.char_size = f:read('char_size'):all()[1]
+    self.char_length = self.target_char:size(3)
+  end
+
+  self.length = self.batch_l:size(1)
+  self.seq_length = self.target:size(2)
+  self.batches = {}
+  local max_source_l = self.source_l:max()
+  local source_l_rev = torch.ones(max_source_l):long()
+  for i = 1, max_source_l do
+    source_l_rev[i] = max_source_l - i + 1
+  end
+  for i = 1, self.length do
+    local source_i, target_i
+    local target_output_i = self.target_output:sub(self.batch_idx[i],self.batch_idx[i]
+      +self.batch_l[i]-1, 1, self.target_l[i])
+    local target_l_i = self.target_l_all:sub(self.batch_idx[i],
+      self.batch_idx[i]+self.batch_l[i]-1)
+    if opt.use_chars_enc == 1 then
+      source_i = self.source_char:sub(self.batch_idx[i],
+        self.batch_idx[i] + self.batch_l[i]-1, 1,
+        self.source_l[i]):transpose(1,2):contiguous()
+    else
+      source_i = self.source:sub(self.batch_idx[i], self.batch_idx[i]+self.batch_l[i]-1,
+        1, self.source_l[i]):transpose(1,2)
+    end
+    if opt.reverse_src == 1 then
+      source_i = source_i:index(1, source_l_rev[{{max_source_l-self.source_l[i]+1,
+            max_source_l}}])
+    end
+
+    if opt.use_chars_dec == 1 then
+      target_i = self.target_char:sub(self.batch_idx[i],
+        self.batch_idx[i] + self.batch_l[i]-1, 1,
+        self.target_l[i]):transpose(1,2):contiguous()
+    else
+      target_i = self.target:sub(self.batch_idx[i], self.batch_idx[i]+self.batch_l[i]-1,
+        1, self.target_l[i]):transpose(1,2)
+    end
+    table.insert(self.batches, {target_i,
+        target_output_i:transpose(1,2),
+        self.target_nonzeros[i],
+        source_i,
+        self.batch_l[i],
+        self.target_l[i],
+        self.source_l[i],
+        target_l_i})
+  end
 end
 
 function data:size()
-   return self.length
+  return self.length
 end
 
 function data.__index(self, idx)
-   if type(idx) == "string" then
-      return data[idx]
-   else
-      local target_input = self.batches[idx][1]
-      local target_output = self.batches[idx][2]
-      local nonzeros = self.batches[idx][3]
-      local source_input = self.batches[idx][4]      
-      local batch_l = self.batches[idx][5]
-      local target_l = self.batches[idx][6]
-      local source_l = self.batches[idx][7]
-      local target_l_all = self.batches[idx][8]
-      if opt.gpuid >= 0 then --if multi-gpu, source lives in gpuid1, rest on gpuid2
-	 cutorch.setDevice(opt.gpuid)
-	 source_input = source_input:cuda()
-	 if opt.gpuid2 >= 0 then
-	    cutorch.setDevice(opt.gpuid2)
-	 end	 
-	 target_input = target_input:cuda()
-	 target_output = target_output:cuda()
-	 target_l_all = target_l_all:cuda()
+  if type(idx) == "string" then
+    return data[idx]
+  else
+    local target_input = self.batches[idx][1]
+    local target_output = self.batches[idx][2]
+    local nonzeros = self.batches[idx][3]
+    local source_input = self.batches[idx][4]
+    local batch_l = self.batches[idx][5]
+    local target_l = self.batches[idx][6]
+    local source_l = self.batches[idx][7]
+    local target_l_all = self.batches[idx][8]
+    if opt.gpuid >= 0 then --if multi-gpu, source lives in gpuid1, rest on gpuid2
+      cutorch.setDevice(opt.gpuid)
+      source_input = source_input:cuda()
+      if opt.gpuid2 >= 0 then
+        cutorch.setDevice(opt.gpuid2)
       end
-      return {target_input, target_output, nonzeros, source_input,
-	      batch_l, target_l, source_l, target_l_all}
-   end
+      target_input = target_input:cuda()
+      target_output = target_output:cuda()
+      target_l_all = target_l_all:cuda()
+    end
+    return {target_input, target_output, nonzeros, source_input,
+      batch_l, target_l, source_l, target_l_all}
+  end
 end
 
 return data

--- a/model_utils.lua
+++ b/model_utils.lua
@@ -1,95 +1,95 @@
 function clone_many_times(net, T)
-    local clones = {}
+  local clones = {}
 
-    local params, gradParams
+  local params, gradParams
+  if net.parameters then
+    params, gradParams = net:parameters()
+    if params == nil then
+      params = {}
+    end
+  end
+
+  local paramsNoGrad
+  if net.parametersNoGrad then
+    paramsNoGrad = net:parametersNoGrad()
+  end
+
+  local mem = torch.MemoryFile("w"):binary()
+  mem:writeObject(net)
+
+  for t = 1, T do
+    -- We need to use a new reader for each clone.
+    -- We don't want to use the pointers to already read objects.
+    local reader = torch.MemoryFile(mem:storage(), "r"):binary()
+    local clone = reader:readObject()
+    reader:close()
+
     if net.parameters then
-        params, gradParams = net:parameters()
-        if params == nil then
-            params = {}
+      local cloneParams, cloneGradParams = clone:parameters()
+      local cloneParamsNoGrad
+      for i = 1, #params do
+        cloneParams[i]:set(params[i])
+        cloneGradParams[i]:set(gradParams[i])
+      end
+      if paramsNoGrad then
+        cloneParamsNoGrad = clone:parametersNoGrad()
+        for i =1,#paramsNoGrad do
+          cloneParamsNoGrad[i]:set(paramsNoGrad[i])
         end
+      end
     end
 
-    local paramsNoGrad
-    if net.parametersNoGrad then
-        paramsNoGrad = net:parametersNoGrad()
-    end
+    clones[t] = clone
+    collectgarbage()
+  end
 
-    local mem = torch.MemoryFile("w"):binary()
-    mem:writeObject(net)
-
-    for t = 1, T do
-        -- We need to use a new reader for each clone.
-        -- We don't want to use the pointers to already read objects.
-        local reader = torch.MemoryFile(mem:storage(), "r"):binary()
-        local clone = reader:readObject()
-        reader:close()
-
-        if net.parameters then
-            local cloneParams, cloneGradParams = clone:parameters()
-            local cloneParamsNoGrad
-            for i = 1, #params do
-                cloneParams[i]:set(params[i])
-                cloneGradParams[i]:set(gradParams[i])
-            end
-            if paramsNoGrad then
-                cloneParamsNoGrad = clone:parametersNoGrad()
-                for i =1,#paramsNoGrad do
-                    cloneParamsNoGrad[i]:set(paramsNoGrad[i])
-                end
-            end
-        end
-
-        clones[t] = clone
-        collectgarbage()
-    end
-
-    mem:close()
-    return clones
+  mem:close()
+  return clones
 end
 
 function adagrad_step(x, dfdx, lr, state)
-   if not state.var then
-      state.var  = torch.Tensor():typeAs(x):resizeAs(x):zero()
-      state.std = torch.Tensor():typeAs(x):resizeAs(x)
-   end
+  if not state.var then
+    state.var = torch.Tensor():typeAs(x):resizeAs(x):zero()
+    state.std = torch.Tensor():typeAs(x):resizeAs(x)
+  end
 
-   state.var:addcmul(1, dfdx, dfdx)
-   state.std:sqrt(state.var)
-   x:addcdiv(-lr, dfdx, state.std:add(1e-10))
+  state.var:addcmul(1, dfdx, dfdx)
+  state.std:sqrt(state.var)
+  x:addcdiv(-lr, dfdx, state.std:add(1e-10))
 end
 
 function adam_step(x, dfdx, lr, state)
-   local beta1 = state.beta1 or 0.9
-   local beta2 = state.beta2 or 0.999
-   local eps = state.eps or 1e-8
+  local beta1 = state.beta1 or 0.9
+  local beta2 = state.beta2 or 0.999
+  local eps = state.eps or 1e-8
 
-   state.t = state.t or 0
-   state.m = state.m or x.new(dfdx:size()):zero()
-   state.v = state.v or x.new(dfdx:size()):zero()
-   state.denom = state.denom or x.new(dfdx:size()):zero()
+  state.t = state.t or 0
+  state.m = state.m or x.new(dfdx:size()):zero()
+  state.v = state.v or x.new(dfdx:size()):zero()
+  state.denom = state.denom or x.new(dfdx:size()):zero()
 
-   state.t = state.t + 1
-   state.m:mul(beta1):add(1-beta1, dfdx)
-   state.v:mul(beta2):addcmul(1-beta2, dfdx, dfdx)
-   state.denom:copy(state.v):sqrt():add(eps)
+  state.t = state.t + 1
+  state.m:mul(beta1):add(1-beta1, dfdx)
+  state.v:mul(beta2):addcmul(1-beta2, dfdx, dfdx)
+  state.denom:copy(state.v):sqrt():add(eps)
 
-   local bias1 = 1-beta1^state.t
-   local bias2 = 1-beta2^state.t
-   local stepSize = lr * math.sqrt(bias2)/bias1
-   x:addcdiv(-stepSize, state.m, state.denom)
-   
+  local bias1 = 1-beta1^state.t
+  local bias2 = 1-beta2^state.t
+  local stepSize = lr * math.sqrt(bias2)/bias1
+  x:addcdiv(-stepSize, state.m, state.denom)
+
 end
 
 function adadelta_step(x, dfdx, lr, state)
-   local rho = state.rho or 0.9
-   local eps = state.eps or 1e-6
-   state.var = state.var or x.new(dfdx:size()):zero()
-   state.std = state.std or x.new(dfdx:size()):zero()
-   state.delta = state.delta or x.new(dfdx:size()):zero()
-   state.accDelta = state.accDelta or x.new(dfdx:size()):zero()
-   state.var:mul(rho):addcmul(1-rho, dfdx, dfdx)
-   state.std:copy(state.var):add(eps):sqrt()
-   state.delta:copy(state.accDelta):add(eps):sqrt():cdiv(state.std):cmul(dfdx)
-   x:add(-lr, state.delta)
-   state.accDelta:mul(rho):addcmul(1-rho, state.delta, state.delta)   
+  local rho = state.rho or 0.9
+  local eps = state.eps or 1e-6
+  state.var = state.var or x.new(dfdx:size()):zero()
+  state.std = state.std or x.new(dfdx:size()):zero()
+  state.delta = state.delta or x.new(dfdx:size()):zero()
+  state.accDelta = state.accDelta or x.new(dfdx:size()):zero()
+  state.var:mul(rho):addcmul(1-rho, dfdx, dfdx)
+  state.std:copy(state.var):add(eps):sqrt()
+  state.delta:copy(state.accDelta):add(eps):sqrt():cdiv(state.std):cmul(dfdx)
+  x:add(-lr, state.delta)
+  state.accDelta:mul(rho):addcmul(1-rho, state.delta, state.delta)
 end

--- a/models.lua
+++ b/models.lua
@@ -1,94 +1,93 @@
-
 function nn.Module:reuseMem()
-   self.reuse = true
-   return self
+  self.reuse = true
+  return self
 end
 
 function nn.Module:setReuse()
-   if self.reuse then
-      self.gradInput = self.output
-   end
+  if self.reuse then
+    self.gradInput = self.output
+  end
 end
 
 function make_lstm(data, opt, model, use_chars)
-   assert(model == 'enc' or model == 'dec')
-   local name = '_' .. model
-   local dropout = opt.dropout or 0
-   local n = opt.num_layers
-   local rnn_size = opt.rnn_size
-   local input_size
-   if use_chars == 0 then
-      input_size = opt.word_vec_size
-   else
-      input_size = opt.num_kernels
-   end   
-   local offset = 0
+  assert(model == 'enc' or model == 'dec')
+  local name = '_' .. model
+  local dropout = opt.dropout or 0
+  local n = opt.num_layers
+  local rnn_size = opt.rnn_size
+  local input_size
+  if use_chars == 0 then
+    input_size = opt.word_vec_size
+  else
+    input_size = opt.num_kernels
+  end
+  local offset = 0
   -- there will be 2*n+3 inputs
-   local inputs = {}
-   table.insert(inputs, nn.Identity()()) -- x (batch_size x max_word_l)
-   if model == 'dec' then
-      table.insert(inputs, nn.Identity()()) -- all context (batch_size x source_l x rnn_size)
+  local inputs = {}
+  table.insert(inputs, nn.Identity()()) -- x (batch_size x max_word_l)
+  if model == 'dec' then
+    table.insert(inputs, nn.Identity()()) -- all context (batch_size x source_l x rnn_size)
+    offset = offset + 1
+    if opt.input_feed == 1 then
+      table.insert(inputs, nn.Identity()()) -- prev context_attn (batch_size x rnn_size)
       offset = offset + 1
-      if opt.input_feed == 1 then
-	 table.insert(inputs, nn.Identity()()) -- prev context_attn (batch_size x rnn_size)
-	 offset = offset + 1
-      end
-   end
-   for L = 1,n do
-      table.insert(inputs, nn.Identity()()) -- prev_c[L]
-      table.insert(inputs, nn.Identity()()) -- prev_h[L]
-   end
-
-   local x, input_size_L
-   local outputs = {}
+    end
+  end
   for L = 1,n do
-     -- c,h from previous timesteps
-    local prev_c = inputs[L*2+offset]    
+    table.insert(inputs, nn.Identity()()) -- prev_c[L]
+    table.insert(inputs, nn.Identity()()) -- prev_h[L]
+  end
+
+  local x, input_size_L
+  local outputs = {}
+  for L = 1,n do
+    -- c,h from previous timesteps
+    local prev_c = inputs[L*2+offset]
     local prev_h = inputs[L*2+1+offset]
     -- the input to this layer
     if L == 1 then
-       if use_chars == 0 then
-	  local word_vecs
-	  if model == 'enc' then
-	     word_vecs = nn.LookupTable(data.source_size, input_size)
-	  else
-	     word_vecs = nn.LookupTable(data.target_size, input_size)
-	  end	  
-	  word_vecs.name = 'word_vecs' .. name
-	  x = word_vecs(inputs[1]) -- batch_size x word_vec_size
-       else
-	  local char_vecs = nn.LookupTable(data.char_size, opt.char_vec_size)
-	  char_vecs.name = 'word_vecs' .. name
-	  local charcnn = make_cnn(opt.char_vec_size,  opt.kernel_width, opt.num_kernels)
-	  charcnn.name = 'charcnn' .. name
-	  x = charcnn(char_vecs(inputs[1]))
-	  if opt.num_highway_layers > 0 then
-	     local mlp = make_highway(input_size, opt.num_highway_layers)
-	     mlp.name = 'mlp' .. name
-	     x = mlp(x)
-	  end	  
-       end
-       input_size_L = input_size
-       if model == 'dec' then
-	  if opt.input_feed == 1 then
-	     x = nn.JoinTable(2)({x, inputs[1+offset]}) -- batch_size x (word_vec_size + rnn_size)
-	     input_size_L = input_size + rnn_size
-	  end	  
-       end
+      if use_chars == 0 then
+        local word_vecs
+        if model == 'enc' then
+          word_vecs = nn.LookupTable(data.source_size, input_size)
+        else
+          word_vecs = nn.LookupTable(data.target_size, input_size)
+        end
+        word_vecs.name = 'word_vecs' .. name
+        x = word_vecs(inputs[1]) -- batch_size x word_vec_size
+      else
+        local char_vecs = nn.LookupTable(data.char_size, opt.char_vec_size)
+        char_vecs.name = 'word_vecs' .. name
+        local charcnn = make_cnn(opt.char_vec_size, opt.kernel_width, opt.num_kernels)
+        charcnn.name = 'charcnn' .. name
+        x = charcnn(char_vecs(inputs[1]))
+        if opt.num_highway_layers > 0 then
+          local mlp = make_highway(input_size, opt.num_highway_layers)
+          mlp.name = 'mlp' .. name
+          x = mlp(x)
+        end
+      end
+      input_size_L = input_size
+      if model == 'dec' then
+        if opt.input_feed == 1 then
+          x = nn.JoinTable(2)({x, inputs[1+offset]}) -- batch_size x (word_vec_size + rnn_size)
+          input_size_L = input_size + rnn_size
+        end
+      end
     else
-       x = outputs[(L-1)*2]
-       if opt.res_net == 1 and L > 2 then
-	  x = nn.CAddTable()({x, outputs[(L-2)*2]})       
-       end       
-       input_size_L = rnn_size
-       if opt.multi_attn == L and model == 'dec' then
-	  local multi_attn = make_decoder_attn(data, opt, 1)
-	  multi_attn.name = 'multi_attn' .. L
-	  x = multi_attn({x, inputs[2]})
-       end
-       if dropout > 0 then
-	  x = nn.Dropout(dropout, nil, false)(x)
-       end       
+      x = outputs[(L-1)*2]
+      if opt.res_net == 1 and L > 2 then
+        x = nn.CAddTable()({x, outputs[(L-2)*2]})
+      end
+      input_size_L = rnn_size
+      if opt.multi_attn == L and model == 'dec' then
+        local multi_attn = make_decoder_attn(data, opt, 1)
+        multi_attn.name = 'multi_attn' .. L
+        x = multi_attn({x, inputs[2]})
+      end
+      if dropout > 0 then
+        x = nn.Dropout(dropout, nil, false)(x)
+      end
     end
     -- evaluate the input sums at once for efficiency
     local i2h = nn.Linear(input_size_L, 4 * rnn_size):reuseMem()(x)
@@ -104,130 +103,129 @@ function make_lstm(data, opt, model, use_chars)
     -- decode the write inputs
     local in_transform = nn.Tanh():reuseMem()(n4)
     -- perform the LSTM update
-    local next_c           = nn.CAddTable()({
+    local next_c = nn.CAddTable()({
         nn.CMulTable()({forget_gate, prev_c}),
-        nn.CMulTable()({in_gate,     in_transform})
+        nn.CMulTable()({in_gate, in_transform})
       })
     -- gated cells form the output
     local next_h = nn.CMulTable()({out_gate, nn.Tanh():reuseMem()(next_c)})
-    
+
     table.insert(outputs, next_c)
     table.insert(outputs, next_h)
   end
   if model == 'dec' then
-     local top_h = outputs[#outputs]
-     local decoder_out
-     if opt.attn == 1 then
-	local decoder_attn = make_decoder_attn(data, opt)
-	decoder_attn.name = 'decoder_attn'
-	decoder_out = decoder_attn({top_h, inputs[2]})
-     else
-	decoder_out = nn.JoinTable(2)({top_h, inputs[2]})
-	decoder_out = nn.Tanh()(nn.LinearNoBias(opt.rnn_size*2, opt.rnn_size)(decoder_out))
-     end
-     if dropout > 0 then
-	decoder_out = nn.Dropout(dropout, nil, false)(decoder_out)
-     end     
-     table.insert(outputs, decoder_out)
+    local top_h = outputs[#outputs]
+    local decoder_out
+    if opt.attn == 1 then
+      local decoder_attn = make_decoder_attn(data, opt)
+      decoder_attn.name = 'decoder_attn'
+      decoder_out = decoder_attn({top_h, inputs[2]})
+    else
+      decoder_out = nn.JoinTable(2)({top_h, inputs[2]})
+      decoder_out = nn.Tanh()(nn.LinearNoBias(opt.rnn_size*2, opt.rnn_size)(decoder_out))
+    end
+    if dropout > 0 then
+      decoder_out = nn.Dropout(dropout, nil, false)(decoder_out)
+    end
+    table.insert(outputs, decoder_out)
   end
   return nn.gModule(inputs, outputs)
 end
 
 function make_decoder_attn(data, opt, simple)
-   -- 2D tensor target_t (batch_l x rnn_size) and
-   -- 3D tensor for context (batch_l x source_l x rnn_size)
+  -- 2D tensor target_t (batch_l x rnn_size) and
+  -- 3D tensor for context (batch_l x source_l x rnn_size)
 
-   local inputs = {}
-   table.insert(inputs, nn.Identity()())
-   table.insert(inputs, nn.Identity()())
-   local target_t = nn.LinearNoBias(opt.rnn_size, opt.rnn_size)(inputs[1])
-   local context = inputs[2]
-   simple = simple or 0
-   -- get attention
+  local inputs = {}
+  table.insert(inputs, nn.Identity()())
+  table.insert(inputs, nn.Identity()())
+  local target_t = nn.LinearNoBias(opt.rnn_size, opt.rnn_size)(inputs[1])
+  local context = inputs[2]
+  simple = simple or 0
+  -- get attention
 
-   local attn = nn.MM()({context, nn.Replicate(1,3)(target_t)}) -- batch_l x source_l x 1
-   attn = nn.Sum(3)(attn)
-   local softmax_attn = nn.SoftMax()
-   softmax_attn.name = 'softmax_attn'
-   attn = softmax_attn(attn)
-   attn = nn.Replicate(1,2)(attn) -- batch_l x  1 x source_l
-   
-   -- apply attention to context
-   local context_combined = nn.MM()({attn, context}) -- batch_l x 1 x rnn_size
-   context_combined = nn.Sum(2)(context_combined) -- batch_l x rnn_size
-   local context_output
-   if simple == 0 then
-      context_combined = nn.JoinTable(2)({context_combined, inputs[1]}) -- batch_l x rnn_size*2
-      context_output = nn.Tanh()(nn.LinearNoBias(opt.rnn_size*2,
-						 opt.rnn_size)(context_combined))
-   else
-      context_output = nn.CAddTable()({context_combined,inputs[1]})
-   end   
-   return nn.gModule(inputs, {context_output})   
+  local attn = nn.MM()({context, nn.Replicate(1,3)(target_t)}) -- batch_l x source_l x 1
+  attn = nn.Sum(3)(attn)
+  local softmax_attn = nn.SoftMax()
+  softmax_attn.name = 'softmax_attn'
+  attn = softmax_attn(attn)
+  attn = nn.Replicate(1,2)(attn) -- batch_l x 1 x source_l
+
+  -- apply attention to context
+  local context_combined = nn.MM()({attn, context}) -- batch_l x 1 x rnn_size
+  context_combined = nn.Sum(2)(context_combined) -- batch_l x rnn_size
+  local context_output
+  if simple == 0 then
+    context_combined = nn.JoinTable(2)({context_combined, inputs[1]}) -- batch_l x rnn_size*2
+    context_output = nn.Tanh()(nn.LinearNoBias(opt.rnn_size*2,
+        opt.rnn_size)(context_combined))
+  else
+    context_output = nn.CAddTable()({context_combined,inputs[1]})
+  end
+  return nn.gModule(inputs, {context_output})
 end
 
 function make_generator(data, opt)
-   local model = nn.Sequential()
-   model:add(nn.Linear(opt.rnn_size, data.target_size))
-   model:add(nn.LogSoftMax())
-   local w = torch.ones(data.target_size)
-   w[1] = 0
-   criterion = nn.ClassNLLCriterion(w)
-   criterion.sizeAverage = false
-   return model, criterion
+  local model = nn.Sequential()
+  model:add(nn.Linear(opt.rnn_size, data.target_size))
+  model:add(nn.LogSoftMax())
+  local w = torch.ones(data.target_size)
+  w[1] = 0
+  criterion = nn.ClassNLLCriterion(w)
+  criterion.sizeAverage = false
+  return model, criterion
 end
-
 
 -- cnn Unit
 function make_cnn(input_size, kernel_width, num_kernels)
-   local output
-   local input = nn.Identity()() 
-   if opt.cudnn == 1 then
-      local conv = cudnn.SpatialConvolution(1, num_kernels, input_size,
-					    kernel_width, 1, 1, 0)
-      local conv_layer = conv(nn.View(1, -1, input_size):setNumInputDims(2)(input))
-      output = nn.Sum(3)(nn.Max(3)(nn.Tanh()(conv_layer)))
-   else
-      local conv = nn.TemporalConvolution(input_size, num_kernels, kernel_width)
-      local conv_layer = conv(input)
-      output = nn.Max(2)(nn.Tanh()(conv_layer))
-   end
-   return nn.gModule({input}, {output})
+  local output
+  local input = nn.Identity()()
+  if opt.cudnn == 1 then
+    local conv = cudnn.SpatialConvolution(1, num_kernels, input_size,
+      kernel_width, 1, 1, 0)
+    local conv_layer = conv(nn.View(1, -1, input_size):setNumInputDims(2)(input))
+    output = nn.Sum(3)(nn.Max(3)(nn.Tanh()(conv_layer)))
+  else
+    local conv = nn.TemporalConvolution(input_size, num_kernels, kernel_width)
+    local conv_layer = conv(input)
+    output = nn.Max(2)(nn.Tanh()(conv_layer))
+  end
+  return nn.gModule({input}, {output})
 end
 
 function make_highway(input_size, num_layers, output_size, bias, f)
-    -- size = dimensionality of inputs
-    -- num_layers = number of hidden layers (default = 1)
-    -- bias = bias for transform gate (default = -2)
-    -- f = non-linearity (default = ReLU)
-    
-    local num_layers = num_layers or 1
-    local input_size = input_size
-    local output_size = output_size or input_size
-    local bias = bias or -2
-    local f = f or nn.ReLU()
-    local start = nn.Identity()()
-    local transform_gate, carry_gate, input, output
-    for i = 1, num_layers do
-       if i > 1 then
-	  input_size = output_size
-       else
-	  input = start
-       end       
-       output = f(nn.Linear(input_size, output_size)(input))
-       transform_gate = nn.Sigmoid()(nn.AddConstant(bias, true)(
-					nn.Linear(input_size, output_size)(input)))
-       carry_gate = nn.AddConstant(1, true)(nn.MulConstant(-1)(transform_gate))
-       local proj
-       if input_size==output_size then
-	  proj = nn.Identity()
-       else
-	  proj = nn.LinearNoBias(input_size, output_size)
-       end
-       input = nn.CAddTable()({
-	                     nn.CMulTable()({transform_gate, output}),
-                             nn.CMulTable()({carry_gate, proj(input)})})
+  -- size = dimensionality of inputs
+  -- num_layers = number of hidden layers (default = 1)
+  -- bias = bias for transform gate (default = -2)
+  -- f = non-linearity (default = ReLU)
+
+  local num_layers = num_layers or 1
+  local input_size = input_size
+  local output_size = output_size or input_size
+  local bias = bias or -2
+  local f = f or nn.ReLU()
+  local start = nn.Identity()()
+  local transform_gate, carry_gate, input, output
+  for i = 1, num_layers do
+    if i > 1 then
+      input_size = output_size
+    else
+      input = start
     end
-    return nn.gModule({start},{input})
+    output = f(nn.Linear(input_size, output_size)(input))
+    transform_gate = nn.Sigmoid()(nn.AddConstant(bias, true)(
+        nn.Linear(input_size, output_size)(input)))
+    carry_gate = nn.AddConstant(1, true)(nn.MulConstant(-1)(transform_gate))
+    local proj
+    if input_size==output_size then
+      proj = nn.Identity()
+    else
+      proj = nn.LinearNoBias(input_size, output_size)
+    end
+    input = nn.CAddTable()({
+        nn.CMulTable()({transform_gate, output}),
+        nn.CMulTable()({carry_gate, proj(input)})})
+  end
+  return nn.gModule({start},{input})
 end
 

--- a/models.lua
+++ b/models.lua
@@ -1,3 +1,5 @@
+dofile 'util.lua'
+
 function nn.Module:reuseMem()
   self.reuse = true
   return self

--- a/train.lua
+++ b/train.lua
@@ -2,10 +2,10 @@ require 'nn'
 require 'nngraph'
 require 'hdf5'
 
-require 'data.lua'
-require 'util.lua'
-require 'models.lua'
-require 'model_utils.lua'
+require 'data'
+require 'util'
+require 'models'
+require 'model_utils'
 
 cmd = torch.CmdLine()
 
@@ -13,17 +13,14 @@ cmd = torch.CmdLine()
 cmd:text("")
 cmd:text("**Data options**")
 cmd:text("")
-cmd:option('-data_file','data/demo-train.hdf5',[[Path to the training *.hdf5 file 
-                                               from preprocess.py]])
-cmd:option('-val_data_file','data/demo-val.hdf5',[[Path to validation *.hdf5 file 
-                                                 from preprocess.py]])
-cmd:option('-savefile', 'seq2seq_lstm_attn', [[Savefile name (model will be saved as 
-                         savefile_epochX_PPL.t7 where X is the X-th epoch and PPL is 
-                         the validation perplexity]])
-cmd:option('-num_shards', 0, [[If the training data has been broken up into different shards, 
+cmd:option('-data_file','data/demo-train.hdf5', [[Path to the training *.hdf5 file from preprocess.py]])
+cmd:option('-val_data_file','data/demo-val.hdf5', [[Path to validation *.hdf5 file from preprocess.py]])
+cmd:option('-savefile', 'seq2seq_lstm_attn', [[Savefile name (model will be saved as
+                                             savefile_epochX_PPL.t7 where X is the X-th epoch and PPL is
+                                             the validation perplexity]])
+cmd:option('-num_shards', 0, [[If the training data has been broken up into different shards,
                              then training files are in this many partitions]])
-cmd:option('-train_from', '', [[If training from a checkpoint then this is the path to the
-                                pretrained model.]])
+cmd:option('-train_from', '', [[If training from a checkpoint then this is the path to the pretrained model.]])
 
 -- rnn model specs
 cmd:text("")
@@ -35,29 +32,26 @@ cmd:option('-rnn_size', 500, [[Size of LSTM hidden states]])
 cmd:option('-word_vec_size', 500, [[Word embedding sizes]])
 cmd:option('-attn', 1, [[If = 1, use attention on the decoder side. If = 0, it uses the last
                        hidden state of the decoder as context at each time step.]])
-cmd:option('-brnn', 0, [[If = 1, use a bidirectional RNN. Hidden states of the fwd/bwd
-                              RNNs are summed.]])
-cmd:option('-use_chars_enc', 0, [[If = 1, use character on the encoder 
-                                side (instead of word embeddings]])
-cmd:option('-use_chars_dec', 0, [[If = 1, use character on the decoder 
-                                side (instead of word embeddings]])
-cmd:option('-reverse_src', 0, [[If = 1, reverse the source sequence. The original 
-                              sequence-to-sequence paper found that this was crucial to 
+cmd:option('-brnn', 0, [[If = 1, use a bidirectional RNN. Hidden states of the fwd/bwd RNNs are summed.]])
+cmd:option('-use_chars_enc', 0, [[If = 1, use character on the encoder side (instead of word embeddings]])
+cmd:option('-use_chars_dec', 0, [[If = 1, use character on the decoder side (instead of word embeddings]])
+cmd:option('-reverse_src', 0, [[If = 1, reverse the source sequence. The original
+                              sequence-to-sequence paper found that this was crucial to
                               achieving good performance, but with attention models this
                               does not seem necessary. Recommend leaving it to 0]])
-cmd:option('-init_dec', 1, [[Initialize the hidden/cell state of the decoder at time 
-                           0 to be the last hidden/cell state of the encoder. If 0, 
+cmd:option('-init_dec', 1, [[Initialize the hidden/cell state of the decoder at time
+                           0 to be the last hidden/cell state of the encoder. If 0,
                            the initial states of the decoder are set to zero vectors]])
 cmd:option('-input_feed', 1, [[If = 1, feed the context vector at each time step as additional
                              input (vica concatenation with the word embeddings) to the decoder]])
-cmd:option('-multi_attn', 0, [[If > 0, then use a another attention layer on this layer of 
-                           the decoder. For example, if num_layers = 3 and `multi_attn = 2`, 
-                           then the model will do an attention over the source sequence
-                           on the second layer (and use that as input to the third layer) and 
-                           the penultimate layer]])
-cmd:option('-res_net', 0, [[Use residual connections between LSTM stacks whereby the input to 
-                          the l-th LSTM layer if the hidden state of the l-1-th LSTM layer 
-                          added with the l-2th LSTM layer. We didn't find this to help in our 
+cmd:option('-multi_attn', 0, [[If > 0, then use a another attention layer on this layer of
+                             the decoder. For example, if num_layers = 3 and `multi_attn = 2`,
+                             then the model will do an attention over the source sequence
+                             on the second layer (and use that as input to the third layer) and
+                             the penultimate layer]])
+cmd:option('-res_net', 0, [[Use residual connections between LSTM stacks whereby the input to
+                          the l-th LSTM layer if the hidden state of the l-1-th LSTM layer
+                          added with the l-2th LSTM layer. We didn't find this to help in our
                           experiments]])
 
 cmd:text("")
@@ -78,818 +72,813 @@ cmd:text("")
 -- optimization
 cmd:option('-epochs', 13, [[Number of training epochs]])
 cmd:option('-start_epoch', 1, [[If loading from a checkpoint, the epoch from which to start]])
-cmd:option('-param_init', 0.1, [[Parameters are initialized over uniform distribution with support
-                               (-param_init, param_init)]])
-cmd:option('-optim', 'sgd', [[Optimization method. Possible options are: 
-                              sgd (vanilla SGD), adagrad, adadelta, adam]])
-cmd:option('-learning_rate', 1, [[Starting learning rate. If adagrad/adadelta/adam is used, 
+cmd:option('-param_init', 0.1, [[Parameters are initialized over uniform distribution with support (-param_init, param_init)]])
+cmd:option('-optim', 'sgd', [[Optimization method. Possible options are: sgd (vanilla SGD), adagrad, adadelta, adam]])
+cmd:option('-learning_rate', 1, [[Starting learning rate. If adagrad/adadelta/adam is used,
                                 then this is the global learning rate. Recommended settings: sgd =1,
                                 adagrad = 0.1, adadelta = 1, adam = 0.1]])
-cmd:option('-max_grad_norm', 5, [[If the norm of the gradient vector exceeds this renormalize it
-                               to have the norm equal to max_grad_norm]])
-cmd:option('-dropout', 0.3, [[Dropout probability. 
-                            Dropout is applied between vertical LSTM stacks.]])
+cmd:option('-max_grad_norm', 5, [[If the norm of the gradient vector exceeds this renormalize it to have the norm equal to max_grad_norm]])
+cmd:option('-dropout', 0.3, [[Dropout probability. Dropout is applied between vertical LSTM stacks.]])
 cmd:option('-lr_decay', 0.5, [[Decay learning rate by this much if (i) perplexity does not decrease
-                      on the validation set or (ii) epoch has gone past the start_decay_at_limit]])
+                             on the validation set or (ii) epoch has gone past the start_decay_at_limit]])
 cmd:option('-start_decay_at', 9, [[Start decay after this epoch]])
 cmd:option('-curriculum', 0, [[For this many epochs, order the minibatches based on source
-                sequence length. Sometimes setting this to 1 will increase convergence speed.]])
-cmd:option('-pre_word_vecs_enc', '', [[If a valid path is specified, then this will load 
-                                      pretrained word embeddings (hdf5 file) on the encoder side. 
-                                      See README for specific formatting instructions.]])
-cmd:option('-pre_word_vecs_dec', '', [[If a valid path is specified, then this will load 
-                                      pretrained word embeddings (hdf5 file) on the decoder side. 
-                                      See README for specific formatting instructions.]])
+                             sequence length. Sometimes setting this to 1 will increase convergence speed.]])
+cmd:option('-pre_word_vecs_enc', '', [[If a valid path is specified, then this will load
+                                     pretrained word embeddings (hdf5 file) on the encoder side.
+                                     See README for specific formatting instructions.]])
+cmd:option('-pre_word_vecs_dec', '', [[If a valid path is specified, then this will load
+                                     pretrained word embeddings (hdf5 file) on the decoder side.
+                                     See README for specific formatting instructions.]])
 cmd:option('-fix_word_vecs_enc', 0, [[If = 1, fix word embeddings on the encoder side]])
 cmd:option('-fix_word_vecs_dec', 0, [[If = 1, fix word embeddings on the decoder side]])
-cmd:option('-max_batch_l', '', [[If blank, then it will infer the max batch size from validation 
+cmd:option('-max_batch_l', '', [[If blank, then it will infer the max batch size from validation
                                data. You should only use this if your validation set uses a different
                                batch size in the preprocessing step]])
+
 cmd:text("")
 cmd:text("**Other options**")
 cmd:text("")
 
-
 cmd:option('-start_symbol', 0, [[Use special start-of-sentence and end-of-sentence tokens
-                       on the source side. We've found this to make minimal difference]])
+                               on the source side. We've found this to make minimal difference]])
 -- GPU
 cmd:option('-gpuid', -1, [[Which gpu to use. -1 = use CPU]])
 cmd:option('-gpuid2', -1, [[If this is >= 0, then the model will use two GPUs whereby the encoder
-                           is on the first GPU and the decoder is on the second GPU. 
-                           This will allow you to train with bigger batches/models.]])
+                          is on the first GPU and the decoder is on the second GPU.
+                          This will allow you to train with bigger batches/models.]])
 cmd:option('-cudnn', 0, [[Whether to use cudnn or not for convolutions (for the character model).
-                         cudnn has much faster convolutions so this is highly recommended 
-                         if using the character model]])
+                        cudnn has much faster convolutions so this is highly recommended
+                        if using the character model]])
 -- bookkeeping
 cmd:option('-save_every', 1, [[Save every this many epochs]])
 cmd:option('-print_every', 50, [[Print stats after this many batches]])
 cmd:option('-seed', 3435, [[Seed for random initialization]])
 
-opt = cmd:parse(arg)
-torch.manualSeed(opt.seed)
-
 function zero_table(t)
-   for i = 1, #t do
-      if opt.gpuid >= 0 and opt.gpuid2 >= 0 then
-	 if i == 1 then
-	    cutorch.setDevice(opt.gpuid)
-	 else
-	    cutorch.setDevice(opt.gpuid2)
-	 end
+  for i = 1, #t do
+    if opt.gpuid >= 0 and opt.gpuid2 >= 0 then
+      if i == 1 then
+        cutorch.setDevice(opt.gpuid)
+      else
+        cutorch.setDevice(opt.gpuid2)
       end
-      t[i]:zero()
-   end
+    end
+    t[i]:zero()
+  end
 end
 
 function train(train_data, valid_data)
 
-   local timer = torch.Timer()
-   local num_params = 0
-   local start_decay = 0
-   params, grad_params = {}, {}
-   opt.train_perf = {}
-   opt.val_perf = {}
-   
-   for i = 1, #layers do
-      if opt.gpuid2 >= 0 then
-	 if i == 1 then
-	    cutorch.setDevice(opt.gpuid)
-	 else
-	    cutorch.setDevice(opt.gpuid2)
-	 end
-      end      
-      local p, gp = layers[i]:getParameters()
-      if opt.train_from:len() == 0 then
-	 p:uniform(-opt.param_init, opt.param_init)
-      end
-      num_params = num_params + p:size(1)
-      params[i] = p
-      grad_params[i] = gp
-   end
+  local timer = torch.Timer()
+  local num_params = 0
+  local start_decay = 0
+  params, grad_params = {}, {}
+  opt.train_perf = {}
+  opt.val_perf = {}
 
-   if opt.pre_word_vecs_enc:len() > 0 then   
-      local f = hdf5.open(opt.pre_word_vecs_enc)     
-      local pre_word_vecs = f:read('word_vecs'):all()
-      for i = 1, pre_word_vecs:size(1) do
-	 word_vec_layers[1].weight[i]:copy(pre_word_vecs[i])
-      end      
-   end
-   if opt.pre_word_vecs_dec:len() > 0 then      
-      local f = hdf5.open(opt.pre_word_vecs_dec)     
-      local pre_word_vecs = f:read('word_vecs'):all()
-      for i = 1, pre_word_vecs:size(1) do
-	 word_vec_layers[2].weight[i]:copy(pre_word_vecs[i])
-      end      
-   end
-   if opt.brnn == 1 then --subtract shared params for brnn
-      num_params = num_params - word_vec_layers[1].weight:nElement()
-      word_vec_layers[3].weight:copy(word_vec_layers[1].weight)
-      if opt.use_chars_enc == 1 then
-      	 for i = 1, charcnn_offset do
-      	    num_params = num_params - charcnn_layers[i]:nElement()
-      	    charcnn_layers[i+charcnn_offset]:copy(charcnn_layers[i])
-      	 end	 
-      end            
-   end
-   print("Number of parameters: " .. num_params)
-   
-   if opt.gpuid >= 0 and opt.gpuid2 >= 0 then
+  for i = 1, #layers do
+    if opt.gpuid2 >= 0 then
+      if i == 1 then
+        cutorch.setDevice(opt.gpuid)
+      else
+        cutorch.setDevice(opt.gpuid2)
+      end
+    end
+    local p, gp = layers[i]:getParameters()
+    if opt.train_from:len() == 0 then
+      p:uniform(-opt.param_init, opt.param_init)
+    end
+    num_params = num_params + p:size(1)
+    params[i] = p
+    grad_params[i] = gp
+  end
+
+  if opt.pre_word_vecs_enc:len() > 0 then
+    local f = hdf5.open(opt.pre_word_vecs_enc)
+    local pre_word_vecs = f:read('word_vecs'):all()
+    for i = 1, pre_word_vecs:size(1) do
+      word_vec_layers[1].weight[i]:copy(pre_word_vecs[i])
+    end
+  end
+  if opt.pre_word_vecs_dec:len() > 0 then
+    local f = hdf5.open(opt.pre_word_vecs_dec)
+    local pre_word_vecs = f:read('word_vecs'):all()
+    for i = 1, pre_word_vecs:size(1) do
+      word_vec_layers[2].weight[i]:copy(pre_word_vecs[i])
+    end
+  end
+  if opt.brnn == 1 then --subtract shared params for brnn
+    num_params = num_params - word_vec_layers[1].weight:nElement()
+    word_vec_layers[3].weight:copy(word_vec_layers[1].weight)
+    if opt.use_chars_enc == 1 then
+      for i = 1, charcnn_offset do
+        num_params = num_params - charcnn_layers[i]:nElement()
+        charcnn_layers[i+charcnn_offset]:copy(charcnn_layers[i])
+      end
+    end
+  end
+  print("Number of parameters: " .. num_params)
+
+  if opt.gpuid >= 0 and opt.gpuid2 >= 0 then
+    cutorch.setDevice(opt.gpuid)
+    word_vec_layers[1].weight[1]:zero()
+    cutorch.setDevice(opt.gpuid2)
+    word_vec_layers[2].weight[1]:zero()
+  else
+    word_vec_layers[1].weight[1]:zero()
+    word_vec_layers[2].weight[1]:zero()
+    if opt.brnn == 1 then
+      word_vec_layers[3].weight[1]:zero()
+    end
+  end
+
+  -- prototypes for gradients so there is no need to clone
+  encoder_grad_proto = torch.zeros(opt.max_batch_l, opt.max_sent_l, opt.rnn_size)
+  encoder_bwd_grad_proto = torch.zeros(opt.max_batch_l, opt.max_sent_l, opt.rnn_size)
+  context_proto = torch.zeros(opt.max_batch_l, opt.max_sent_l, opt.rnn_size)
+  -- need more copies of the above if using two gpus
+  if opt.gpuid2 >= 0 then
+    encoder_grad_proto2 = torch.zeros(opt.max_batch_l, opt.max_sent_l, opt.rnn_size)
+    context_proto2 = torch.zeros(opt.max_batch_l, opt.max_sent_l, opt.rnn_size)
+    encoder_bwd_grad_proto2 = torch.zeros(opt.max_batch_l, opt.max_sent_l, opt.rnn_size)
+  end
+
+  -- clone encoder/decoder up to max source/target length
+  decoder_clones = clone_many_times(decoder, opt.max_sent_l_targ)
+  encoder_clones = clone_many_times(encoder, opt.max_sent_l_src)
+  if opt.brnn == 1 then
+    encoder_bwd_clones = clone_many_times(encoder_bwd, opt.max_sent_l_src)
+  end
+  for i = 1, opt.max_sent_l_src do
+    if encoder_clones[i].apply then
+      encoder_clones[i]:apply(function(m) m:setReuse() end)
+    end
+    if opt.brnn == 1 then
+      encoder_bwd_clones[i]:apply(function(m) m:setReuse() end)
+    end
+  end
+  for i = 1, opt.max_sent_l_targ do
+    if decoder_clones[i].apply then
+      decoder_clones[i]:apply(function(m) m:setReuse() end)
+    end
+  end
+
+  local h_init = torch.zeros(opt.max_batch_l, opt.rnn_size)
+  if opt.gpuid >= 0 then
+    h_init = h_init:cuda()
+    cutorch.setDevice(opt.gpuid)
+    if opt.gpuid2 >= 0 then
+      encoder_grad_proto2 = encoder_grad_proto2:cuda()
+      encoder_bwd_grad_proto2 = encoder_bwd_grad_proto2:cuda()
+      context_proto = context_proto:cuda()
+      cutorch.setDevice(opt.gpuid2)
+      encoder_grad_proto = encoder_grad_proto:cuda()
+      encoder_bwd_grad_proto = encoder_bwd_grad_proto:cuda()
+      context_proto2 = context_proto2:cuda()
       cutorch.setDevice(opt.gpuid)
-      word_vec_layers[1].weight[1]:zero()
-      cutorch.setDevice(opt.gpuid2)
-      word_vec_layers[2].weight[1]:zero()
-   else
-      word_vec_layers[1].weight[1]:zero()            
-      word_vec_layers[2].weight[1]:zero()
+    else
+      context_proto = context_proto:cuda()
+      encoder_grad_proto = encoder_grad_proto:cuda()
       if opt.brnn == 1 then
-	 word_vec_layers[3].weight[1]:zero()
-      end      
-   end         
-   
-   -- prototypes for gradients so there is no need to clone
-   encoder_grad_proto = torch.zeros(opt.max_batch_l, opt.max_sent_l, opt.rnn_size)
-   encoder_bwd_grad_proto = torch.zeros(opt.max_batch_l, opt.max_sent_l, opt.rnn_size)
-   context_proto = torch.zeros(opt.max_batch_l, opt.max_sent_l, opt.rnn_size)
-   -- need more copies of the above if using two gpus
-   if opt.gpuid2 >= 0 then
-      encoder_grad_proto2 = torch.zeros(opt.max_batch_l, opt.max_sent_l, opt.rnn_size)
-      context_proto2 = torch.zeros(opt.max_batch_l, opt.max_sent_l, opt.rnn_size)
-      encoder_bwd_grad_proto2 = torch.zeros(opt.max_batch_l, opt.max_sent_l, opt.rnn_size)      
-   end
-      
-   -- clone encoder/decoder up to max source/target length   
-   decoder_clones = clone_many_times(decoder, opt.max_sent_l_targ)
-   encoder_clones = clone_many_times(encoder, opt.max_sent_l_src)
-   if opt.brnn == 1 then
-      encoder_bwd_clones = clone_many_times(encoder_bwd, opt.max_sent_l_src)
-   end   
-   for i = 1, opt.max_sent_l_src do
-      if encoder_clones[i].apply then
-	 encoder_clones[i]:apply(function(m) m:setReuse() end)
+        encoder_bwd_grad_proto = encoder_bwd_grad_proto:cuda()
       end
-      if opt.brnn == 1 then
-	 encoder_bwd_clones[i]:apply(function(m) m:setReuse() end)
-      end      
-   end
-   for i = 1, opt.max_sent_l_targ do
-      if decoder_clones[i].apply then
-	 decoder_clones[i]:apply(function(m) m:setReuse() end)
-      end
-   end   
+    end
+  end
 
-   local h_init = torch.zeros(opt.max_batch_l, opt.rnn_size)
-   if opt.gpuid >= 0 then
-      h_init = h_init:cuda()
-      cutorch.setDevice(opt.gpuid)                        
-      if opt.gpuid2 >= 0 then
-	 encoder_grad_proto2 = encoder_grad_proto2:cuda()
-	 encoder_bwd_grad_proto2 = encoder_bwd_grad_proto2:cuda()
-	 context_proto = context_proto:cuda()	 
-	 cutorch.setDevice(opt.gpuid2)
-	 encoder_grad_proto = encoder_grad_proto:cuda()
-	 encoder_bwd_grad_proto = encoder_bwd_grad_proto:cuda()
-	 context_proto2 = context_proto2:cuda()
-	 cutorch.setDevice(opt.gpuid)	 
+  -- these are initial states of encoder/decoder for fwd/bwd steps
+  init_fwd_enc = {}
+  init_bwd_enc = {}
+  init_fwd_dec = {}
+  init_bwd_dec = {}
+
+  for L = 1, opt.num_layers do
+    table.insert(init_fwd_enc, h_init:clone())
+    table.insert(init_fwd_enc, h_init:clone())
+    table.insert(init_bwd_enc, h_init:clone())
+    table.insert(init_bwd_enc, h_init:clone())
+  end
+  if opt.gpuid2 >= 0 then
+    cutorch.setDevice(opt.gpuid2)
+  end
+  if opt.input_feed == 1 then
+    table.insert(init_fwd_dec, h_init:clone())
+  end
+  table.insert(init_bwd_dec, h_init:clone())
+  for L = 1, opt.num_layers do
+    table.insert(init_fwd_dec, h_init:clone())
+    table.insert(init_fwd_dec, h_init:clone())
+    table.insert(init_bwd_dec, h_init:clone())
+    table.insert(init_bwd_dec, h_init:clone())
+  end
+
+  dec_offset = 3 -- offset depends on input feeding
+  if opt.input_feed == 1 then
+    dec_offset = dec_offset + 1
+  end
+
+  function reset_state(state, batch_l, t)
+    if t == nil then
+      local u = {}
+      for i = 1, #state do
+        state[i]:zero()
+        table.insert(u, state[i][{{1, batch_l}}])
+      end
+      return u
+    else
+      local u = {[t] = {}}
+      for i = 1, #state do
+        state[i]:zero()
+        table.insert(u[t], state[i][{{1, batch_l}}])
+      end
+      return u
+    end
+  end
+
+  -- clean layer before saving to make the model smaller
+  function clean_layer(layer)
+    if opt.gpuid >= 0 then
+      layer.output = torch.CudaTensor()
+      layer.gradInput = torch.CudaTensor()
+    else
+      layer.output = torch.DoubleTensor()
+      layer.gradInput = torch.DoubleTensor()
+    end
+    if layer.modules then
+      for i, mod in ipairs(layer.modules) do
+        clean_layer(mod)
+      end
+    elseif torch.type(self) == "nn.gModule" then
+      layer:apply(clean_layer)
+    end
+  end
+
+  -- decay learning rate if val perf does not improve or we hit the opt.start_decay_at limit
+  function decay_lr(epoch)
+    print(opt.val_perf)
+    if epoch >= opt.start_decay_at then
+      start_decay = 1
+    end
+
+    if opt.val_perf[#opt.val_perf] ~= nil and opt.val_perf[#opt.val_perf-1] ~= nil then
+      local curr_ppl = opt.val_perf[#opt.val_perf]
+      local prev_ppl = opt.val_perf[#opt.val_perf-1]
+      if curr_ppl > prev_ppl then
+        start_decay = 1
+      end
+    end
+    if start_decay == 1 then
+      opt.learning_rate = opt.learning_rate * opt.lr_decay
+    end
+  end
+
+  function train_batch(data, epoch)
+    local train_nonzeros = 0
+    local train_loss = 0
+    local batch_order = torch.randperm(data.length) -- shuffle mini batch order
+    local start_time = timer:time().real
+    local num_words_target = 0
+    local num_words_source = 0
+
+    for i = 1, data:size() do
+      zero_table(grad_params, 'zero')
+      local d
+      if epoch <= opt.curriculum then
+        d = data[i]
       else
-	 context_proto = context_proto:cuda()
-	 encoder_grad_proto = encoder_grad_proto:cuda()
-	 if opt.brnn == 1 then
-	    encoder_bwd_grad_proto = encoder_bwd_grad_proto:cuda()
-	 end	 
+        d = data[batch_order[i]]
       end
-   end
-
-   -- these are initial states of encoder/decoder for fwd/bwd steps
-   init_fwd_enc = {}
-   init_bwd_enc = {}
-   init_fwd_dec = {}
-   init_bwd_dec = {}
-   
-   for L = 1, opt.num_layers do
-      table.insert(init_fwd_enc, h_init:clone())
-      table.insert(init_fwd_enc, h_init:clone())
-      table.insert(init_bwd_enc, h_init:clone())
-      table.insert(init_bwd_enc, h_init:clone())
-   end
-   if opt.gpuid2 >= 0 then
-      cutorch.setDevice(opt.gpuid2)
-   end
-   if opt.input_feed == 1 then
-      table.insert(init_fwd_dec, h_init:clone())
-   end
-   table.insert(init_bwd_dec, h_init:clone())   
-   for L = 1, opt.num_layers do
-      table.insert(init_fwd_dec, h_init:clone()) 
-      table.insert(init_fwd_dec, h_init:clone()) 
-      table.insert(init_bwd_dec, h_init:clone())
-      table.insert(init_bwd_dec, h_init:clone())
-   end         
-   
-   dec_offset = 3 -- offset depends on input feeding
-   if opt.input_feed == 1 then
-      dec_offset = dec_offset + 1
-   end
-   
-   function reset_state(state, batch_l, t)
-      if t == nil then
-	 local u = {}
-	 for i = 1, #state do
-	    state[i]:zero()
-	    table.insert(u, state[i][{{1, batch_l}}])
-	 end
-	 return u
-      else
-	 local u = {[t] = {}}
-	 for i = 1, #state do
-	    state[i]:zero()
-	    table.insert(u[t], state[i][{{1, batch_l}}])
-	 end
-	 return u
-      end      
-   end
-
-   -- clean layer before saving to make the model smaller
-   function clean_layer(layer)
-      if opt.gpuid >= 0 then
-	 layer.output = torch.CudaTensor()
-	 layer.gradInput = torch.CudaTensor()
-      else
-	 layer.output = torch.DoubleTensor()
-	 layer.gradInput = torch.DoubleTensor()
-      end
-      if layer.modules then
-	 for i, mod in ipairs(layer.modules) do
-	    clean_layer(mod)
-	 end
-      elseif torch.type(self) == "nn.gModule" then
-	 layer:apply(clean_layer)
-      end      
-   end
-
-   -- decay learning rate if val perf does not improve or we hit the opt.start_decay_at limit
-   function decay_lr(epoch)
-      print(opt.val_perf)
-      if epoch >= opt.start_decay_at then
-	 start_decay = 1
-      end
-      
-      if opt.val_perf[#opt.val_perf] ~= nil and opt.val_perf[#opt.val_perf-1] ~= nil then
-	 local curr_ppl = opt.val_perf[#opt.val_perf]
-	 local prev_ppl = opt.val_perf[#opt.val_perf-1]
-	 if curr_ppl > prev_ppl then
-	    start_decay = 1
-	 end
-      end
-      if start_decay == 1 then
-	 opt.learning_rate = opt.learning_rate * opt.lr_decay
-      end
-   end   
-
-   function train_batch(data, epoch)
-      local train_nonzeros = 0
-      local train_loss = 0	       
-      local batch_order = torch.randperm(data.length) -- shuffle mini batch order     
-      local start_time = timer:time().real
-      local num_words_target = 0
-      local num_words_source = 0
-      
-      for i = 1, data:size() do
-	 zero_table(grad_params, 'zero')
-	 local d
-         if epoch <= opt.curriculum then
-	    d = data[i]
-	 else
-	    d = data[batch_order[i]]
-	 end
-         local target, target_out, nonzeros, source = d[1], d[2], d[3], d[4]
-	 local batch_l, target_l, source_l = d[5], d[6], d[7]
-	 
-	 local encoder_grads = encoder_grad_proto[{{1, batch_l}, {1, source_l}}]
-	 local encoder_bwd_grads 
-	 if opt.brnn == 1 then
-	    encoder_bwd_grads = encoder_bwd_grad_proto[{{1, batch_l}, {1, source_l}}]
-	 end
-	 if opt.gpuid >= 0 then
-	    cutorch.setDevice(opt.gpuid)
-	 end	 	 
-	 local rnn_state_enc = reset_state(init_fwd_enc, batch_l, 0)
-	 local context = context_proto[{{1, batch_l}, {1, source_l}}]
-	 -- forward prop encoder
-	 for t = 1, source_l do
-	    encoder_clones[t]:training()
-	    local encoder_input = {source[t], table.unpack(rnn_state_enc[t-1])}
-	    local out = encoder_clones[t]:forward(encoder_input)
-	    rnn_state_enc[t] = out
-	    context[{{},t}]:copy(out[#out])
-	 end
-
-	 local rnn_state_enc_bwd
-	 if opt.brnn == 1  then
-	    rnn_state_enc_bwd = reset_state(init_fwd_enc, batch_l, source_l+1)	   	    
-	    for t = source_l, 1, -1 do
-	       encoder_bwd_clones[t]:training()
-	       local encoder_input = {source[t], table.unpack(rnn_state_enc_bwd[t+1])}
-	       local out = encoder_bwd_clones[t]:forward(encoder_input)
-	       rnn_state_enc_bwd[t] = out
-	       context[{{},t}]:add(out[#out])	       
-	    end
-	 end
-	 
-	 if opt.gpuid >= 0 and opt.gpuid2 >= 0 then
-	    cutorch.setDevice(opt.gpuid2)	    
-	    local context2 = context_proto2[{{1, batch_l}, {1, source_l}}]
-	    context2:copy(context)
-	    context = context2
-	 end
-	 -- copy encoder last hidden state to decoder initial state
-	 local rnn_state_dec = reset_state(init_fwd_dec, batch_l, 0)
-	 if opt.init_dec == 1 then
-	    for L = 1, opt.num_layers do
-	       rnn_state_dec[0][L*2-1+opt.input_feed]:copy(rnn_state_enc[source_l][L*2-1])
-	       rnn_state_dec[0][L*2+opt.input_feed]:copy(rnn_state_enc[source_l][L*2])
-	    end
-	    if opt.brnn == 1 then
-	       for L = 1, opt.num_layers do
-		  rnn_state_dec[0][L*2-1+opt.input_feed]:add(rnn_state_enc_bwd[1][L*2-1])
-		  rnn_state_dec[0][L*2+opt.input_feed]:add(rnn_state_enc_bwd[1][L*2])
-	       end
-	    end	 	    	    
-	 end	 
-	 -- forward prop decoder	 
-	 local preds = {}
-	 local decoder_input
-	 for t = 1, target_l do
-	    decoder_clones[t]:training()
-	    local decoder_input
-	    if opt.attn == 1 then
-	       decoder_input = {target[t], context, table.unpack(rnn_state_dec[t-1])}
-	    else
-	       decoder_input = {target[t], context[{{}, source_l}], table.unpack(rnn_state_dec[t-1])}
-	    end	    
-	    local out = decoder_clones[t]:forward(decoder_input)
-	    local next_state = {}
-	    table.insert(preds, out[#out])
-	    if opt.input_feed == 1 then
-	       table.insert(next_state, out[#out])
-	    end
-	    for j = 1, #out-1 do
-	       table.insert(next_state, out[j])
-	    end
-	    rnn_state_dec[t] = next_state
-	 end
-	 
-	 -- backward prop decoder
-	 encoder_grads:zero()
-	 if opt.brnn == 1 then
-	    encoder_bwd_grads:zero()
-	 end
-	 
-	 local drnn_state_dec = reset_state(init_bwd_dec, batch_l)
-	 local loss = 0
-	 for t = target_l, 1, -1 do
-	    local pred = generator:forward(preds[t])
-	    loss = loss + criterion:forward(pred, target_out[t])/batch_l
-	    local dl_dpred = criterion:backward(pred, target_out[t])
-	    dl_dpred:div(batch_l)
-	    local dl_dtarget = generator:backward(preds[t], dl_dpred)
-	    drnn_state_dec[#drnn_state_dec]:add(dl_dtarget)
-	    local decoder_input
-	    if opt.attn == 1 then
-	       decoder_input = {target[t], context, table.unpack(rnn_state_dec[t-1])}
-	    else
-	       decoder_input = {target[t], context[{{}, source_l}], table.unpack(rnn_state_dec[t-1])}
-	    end	    
-	    local dlst = decoder_clones[t]:backward(decoder_input, drnn_state_dec)
-	    -- accumulate encoder/decoder grads
-	    if opt.attn == 1 then
-	       encoder_grads:add(dlst[2])
-	       if opt.brnn == 1 then
-		  encoder_bwd_grads:add(dlst[2])
-	       end	       
-	    else
-	       encoder_grads[{{}, source_l}]:add(dlst[2])
-	       if opt.brnn == 1 then
-		  encoder_bwd_grads[{{}, 1}]:add(dlst[2])
-	       end	       
-	    end	    
-	    drnn_state_dec[#drnn_state_dec]:zero()
-	    if opt.input_feed == 1 then
-	       drnn_state_dec[#drnn_state_dec]:add(dlst[3])
-	    end	    
-	    for j = dec_offset, #dlst do
-	       drnn_state_dec[j-dec_offset+1]:copy(dlst[j])
-	    end	    
-	 end
-         word_vec_layers[2].gradWeight[1]:zero()
-	 if opt.fix_word_vecs_dec == 1 then
-	    word_vec_layers[2].gradWeight:zero()
-	 end
-	 
-	 local grad_norm = 0
-	 grad_norm = grad_norm + grad_params[2]:norm()^2 + grad_params[3]:norm()^2
-
-	 -- backward prop encoder
-	 if opt.gpuid >= 0 and opt.gpuid2 >= 0 then
-	    cutorch.setDevice(opt.gpuid)
-	    local encoder_grads2 = encoder_grad_proto2[{{1, batch_l}, {1, source_l}}]
-	    encoder_grads2:zero()
-	    encoder_grads2:copy(encoder_grads)
-	    encoder_grads = encoder_grads2 -- batch_l x source_l x rnn_size
-	 end
-
-	 local drnn_state_enc = reset_state(init_bwd_enc, batch_l)
-	 if opt.init_dec == 1 then
-	    for L = 1, opt.num_layers do
-	       drnn_state_enc[L*2-1]:copy(drnn_state_dec[L*2-1])
-	       drnn_state_enc[L*2]:copy(drnn_state_dec[L*2])
-	    end	    
-	 end
-	 
-	 for t = source_l, 1, -1 do
-	    local encoder_input = {source[t], table.unpack(rnn_state_enc[t-1])}
-	    if opt.attn == 1 then
-	       drnn_state_enc[#drnn_state_enc]:add(encoder_grads[{{},t}])
-	    else
-	       if t == source_l then
-		  drnn_state_enc[#drnn_state_enc]:add(encoder_grads[{{},t}])
-	       end
-	    end	    		  
-	    local dlst = encoder_clones[t]:backward(encoder_input, drnn_state_enc)
-	    for j = 1, #drnn_state_enc do
-	       drnn_state_enc[j]:copy(dlst[j+1])
-	    end	    
-	 end
-
-	 if opt.brnn == 1 then
-	    local drnn_state_enc = reset_state(init_bwd_enc, batch_l)
-	    if opt.init_dec == 1 then
-	       for L = 1, opt.num_layers do
-		  drnn_state_enc[L*2-1]:copy(drnn_state_dec[L*2-1])
-		  drnn_state_enc[L*2]:copy(drnn_state_dec[L*2])
-	       end
-	    end
-	    for t = 1, source_l do
-	       local encoder_input = {source[t], table.unpack(rnn_state_enc_bwd[t+1])}
-	       if opt.attn == 1 then
-		  drnn_state_enc[#drnn_state_enc]:add(encoder_bwd_grads[{{},t}])
-	       else
-		  if t == 1 then
-		     drnn_state_enc[#drnn_state_enc]:add(encoder_bwd_grads[{{},t}])
-		  end
-	       end
-	       local dlst = encoder_bwd_clones[t]:backward(encoder_input, drnn_state_enc)
-	       for j = 1, #drnn_state_enc do
-		  drnn_state_enc[j]:copy(dlst[j+1])
-	       end
-	    end	      	    
-	 end
-	    	 
-         word_vec_layers[1].gradWeight[1]:zero()
-	 if opt.fix_word_vecs_enc == 1 then
-	    word_vec_layers[1].gradWeight:zero()
-	 end
-	 
-	 grad_norm = grad_norm + grad_params[1]:norm()^2
-	 if opt.brnn == 1 then
-	    grad_norm = grad_norm + grad_params[4]:norm()^2
-	 end
-	 grad_norm = grad_norm^0.5	 
-	 if opt.brnn == 1 then
-	    word_vec_layers[1].gradWeight:add(word_vec_layers[3].gradWeight)
-	    if opt.use_chars_enc == 1 then
-	       for j = 1, charcnn_offset do
-	    	  charcnn_grad_layers[j]:add(charcnn_grad_layers[j+charcnn_offset])
-	       end
-	    end	    
-	 end	 
-         -- Shrink norm and update params
-	 local param_norm = 0
-	 local shrinkage = opt.max_grad_norm / grad_norm
-	 for j = 1, #grad_params do
-	    if opt.gpuid >= 0 and opt.gpuid2 >= 0 then
-	       if j == 1 then
-		  cutorch.setDevice(opt.gpuid)
-	       else
-		  cutorch.setDevice(opt.gpuid2)
-	       end
-	    end
-	    if shrinkage < 1 then
-	       grad_params[j]:mul(shrinkage)
-	    end
-	    if opt.optim == 'adagrad' then
-	       adagrad_step(params[j], grad_params[j], layer_etas[j], optStates[j])
-	    elseif opt.optim == 'adadelta' then
-	       adadelta_step(params[j], grad_params[j], layer_etas[j], optStates[j])
-	    elseif opt.optim == 'adam' then
-	       adam_step(params[j], grad_params[j], layer_etas[j], optStates[j])	       
-	    else
-	       params[j]:add(grad_params[j]:mul(-opt.learning_rate))       
-	    end	    
-	    param_norm = param_norm + params[j]:norm()^2
-	 end	 
-	 param_norm = param_norm^0.5
-	 if opt.brnn == 1 then
-	    word_vec_layers[3].weight:copy(word_vec_layers[1].weight)
-	    if opt.use_chars_enc == 1 then
-	       for j = 1, charcnn_offset do
-	    	  charcnn_layers[j+charcnn_offset]:copy(charcnn_layers[j])
-	       end
-	    end	    
-	 end
-	 
-	 -- Bookkeeping
-	 num_words_target = num_words_target + batch_l*target_l
-	 num_words_source = num_words_source + batch_l*source_l
-	 train_nonzeros = train_nonzeros + nonzeros
-	 train_loss = train_loss + loss*batch_l
-	 local time_taken = timer:time().real - start_time
-         if i % opt.print_every == 0 then
-	    local stats = string.format('Epoch: %d, Batch: %d/%d, Batch size: %d, LR: %.4f, ',
-					epoch, i, data:size(), batch_l, opt.learning_rate)
-	    stats = stats .. string.format('PPL: %.2f, |Param|: %.2f, |GParam|: %.2f, ',
-				  math.exp(train_loss/train_nonzeros), param_norm, grad_norm)
-	    stats = stats .. string.format('Training: %d/%d/%d total/source/target tokens/sec',
-					   (num_words_target+num_words_source) / time_taken,
-					   num_words_source / time_taken,
-					   num_words_target / time_taken)			   
-            print(stats)
-         end
-	 if i % 200 == 0 then
-	    collectgarbage()
-	 end
-      end
-      return train_loss, train_nonzeros
-   end   
-
-   local total_loss, total_nonzeros, batch_loss, batch_nonzeros
-   for epoch = opt.start_epoch, opt.epochs do
-      generator:training()
-      if opt.num_shards > 0 then
-	 total_loss = 0
-	 total_nonzeros = 0	 
-	 local shard_order = torch.randperm(opt.num_shards)
-	 for s = 1, opt.num_shards do
-	    local fn = train_data .. '.' .. shard_order[s] .. '.hdf5'
-	    print('loading shard #' .. shard_order[s])
-	    local shard_data = data.new(opt, fn)
-	    batch_loss, batch_nonzeros = train_batch(shard_data, epoch)
-	    total_loss = total_loss + batch_loss
-	    total_nonzeros = total_nonzeros + batch_nonzeros
-	 end
-      else
-	 total_loss, total_nonzeros = train_batch(train_data, epoch)
-      end
-      local train_score = math.exp(total_loss/total_nonzeros)
-      print('Train', train_score)
-      opt.train_perf[#opt.train_perf + 1] = train_score
-      local score = eval(valid_data)
-      opt.val_perf[#opt.val_perf + 1] = score
-      if opt.optim == 'sgd' then --only decay with SGD
-	 decay_lr(epoch)
-      end      
-      -- clean and save models
-      local savefile = string.format('%s_epoch%.2f_%.2f.t7', opt.savefile, epoch, score)      
-      if epoch % opt.save_every == 0 then
-         print('saving checkpoint to ' .. savefile)
-	 clean_layer(generator)
-	 if opt.brnn == 0 then
-	    torch.save(savefile, {{encoder, decoder, generator}, opt})
-	 else
-	    torch.save(savefile, {{encoder, decoder, generator, encoder_bwd}, opt})
-	 end
-      end      
-   end
-   -- save final model
-   local savefile = string.format('%s_final.t7', opt.savefile)
-   clean_layer(generator)
-   print('saving final model to ' .. savefile)
-   if opt.brnn == 0 then
-      torch.save(savefile, {{encoder:double(), decoder:double(), generator:double()}, opt})
-   else
-      torch.save(savefile, {{encoder:double(), decoder:double(), generator:double(),
-			     encoder_bwd:double()}, opt})
-   end
-end
-   
-function eval(data)
-   encoder_clones[1]:evaluate()   
-   decoder_clones[1]:evaluate() -- just need one clone
-   generator:evaluate()
-   if opt.brnn == 1 then
-      encoder_bwd_clones[1]:evaluate()
-   end
-   
-   local nll = 0
-   local total = 0
-   for i = 1, data:size() do
-      local d = data[i]
       local target, target_out, nonzeros, source = d[1], d[2], d[3], d[4]
       local batch_l, target_l, source_l = d[5], d[6], d[7]
-      if opt.gpuid >= 0 and opt.gpuid2 >= 0 then
-	 cutorch.setDevice(opt.gpuid)
-      end      
-      local rnn_state_enc = reset_state(init_fwd_enc, batch_l)
+
+      local encoder_grads = encoder_grad_proto[{{1, batch_l}, {1, source_l}}]
+      local encoder_bwd_grads
+      if opt.brnn == 1 then
+        encoder_bwd_grads = encoder_bwd_grad_proto[{{1, batch_l}, {1, source_l}}]
+      end
+      if opt.gpuid >= 0 then
+        cutorch.setDevice(opt.gpuid)
+      end
+      local rnn_state_enc = reset_state(init_fwd_enc, batch_l, 0)
       local context = context_proto[{{1, batch_l}, {1, source_l}}]
       -- forward prop encoder
       for t = 1, source_l do
-	 local encoder_input = {source[t], table.unpack(rnn_state_enc)}
-	 local out = encoder_clones[1]:forward(encoder_input)
-	 rnn_state_enc = out
-	 context[{{},t}]:copy(out[#out])
-      end	 
+        encoder_clones[t]:training()
+        local encoder_input = {source[t], table.unpack(rnn_state_enc[t-1])}
+        local out = encoder_clones[t]:forward(encoder_input)
+        rnn_state_enc[t] = out
+        context[{{},t}]:copy(out[#out])
+      end
+
+      local rnn_state_enc_bwd
+      if opt.brnn == 1 then
+        rnn_state_enc_bwd = reset_state(init_fwd_enc, batch_l, source_l+1)
+        for t = source_l, 1, -1 do
+          encoder_bwd_clones[t]:training()
+          local encoder_input = {source[t], table.unpack(rnn_state_enc_bwd[t+1])}
+          local out = encoder_bwd_clones[t]:forward(encoder_input)
+          rnn_state_enc_bwd[t] = out
+          context[{{},t}]:add(out[#out])
+        end
+      end
 
       if opt.gpuid >= 0 and opt.gpuid2 >= 0 then
-	 cutorch.setDevice(opt.gpuid2)
-	 local context2 = context_proto2[{{1, batch_l}, {1, source_l}}]
-	 context2:copy(context)
-	 context = context2
-      end      
-      
-      local rnn_state_dec = reset_state(init_fwd_dec, batch_l)
+        cutorch.setDevice(opt.gpuid2)
+        local context2 = context_proto2[{{1, batch_l}, {1, source_l}}]
+        context2:copy(context)
+        context = context2
+      end
+      -- copy encoder last hidden state to decoder initial state
+      local rnn_state_dec = reset_state(init_fwd_dec, batch_l, 0)
       if opt.init_dec == 1 then
-	 for L = 1, opt.num_layers do
-	    rnn_state_dec[L*2-1+opt.input_feed]:copy(rnn_state_enc[L*2-1])
-	    rnn_state_dec[L*2+opt.input_feed]:copy(rnn_state_enc[L*2])
-	 end	 
+        for L = 1, opt.num_layers do
+          rnn_state_dec[0][L*2-1+opt.input_feed]:copy(rnn_state_enc[source_l][L*2-1])
+          rnn_state_dec[0][L*2+opt.input_feed]:copy(rnn_state_enc[source_l][L*2])
+        end
+        if opt.brnn == 1 then
+          for L = 1, opt.num_layers do
+            rnn_state_dec[0][L*2-1+opt.input_feed]:add(rnn_state_enc_bwd[1][L*2-1])
+            rnn_state_dec[0][L*2+opt.input_feed]:add(rnn_state_enc_bwd[1][L*2])
+          end
+        end
+      end
+      -- forward prop decoder
+      local preds = {}
+      local decoder_input
+      for t = 1, target_l do
+        decoder_clones[t]:training()
+        local decoder_input
+        if opt.attn == 1 then
+          decoder_input = {target[t], context, table.unpack(rnn_state_dec[t-1])}
+        else
+          decoder_input = {target[t], context[{{}, source_l}], table.unpack(rnn_state_dec[t-1])}
+        end
+        local out = decoder_clones[t]:forward(decoder_input)
+        local next_state = {}
+        table.insert(preds, out[#out])
+        if opt.input_feed == 1 then
+          table.insert(next_state, out[#out])
+        end
+        for j = 1, #out-1 do
+          table.insert(next_state, out[j])
+        end
+        rnn_state_dec[t] = next_state
+      end
+
+      -- backward prop decoder
+      encoder_grads:zero()
+      if opt.brnn == 1 then
+        encoder_bwd_grads:zero()
+      end
+
+      local drnn_state_dec = reset_state(init_bwd_dec, batch_l)
+      local loss = 0
+      for t = target_l, 1, -1 do
+        local pred = generator:forward(preds[t])
+        loss = loss + criterion:forward(pred, target_out[t])/batch_l
+        local dl_dpred = criterion:backward(pred, target_out[t])
+        dl_dpred:div(batch_l)
+        local dl_dtarget = generator:backward(preds[t], dl_dpred)
+        drnn_state_dec[#drnn_state_dec]:add(dl_dtarget)
+        local decoder_input
+        if opt.attn == 1 then
+          decoder_input = {target[t], context, table.unpack(rnn_state_dec[t-1])}
+        else
+          decoder_input = {target[t], context[{{}, source_l}], table.unpack(rnn_state_dec[t-1])}
+        end
+        local dlst = decoder_clones[t]:backward(decoder_input, drnn_state_dec)
+        -- accumulate encoder/decoder grads
+        if opt.attn == 1 then
+          encoder_grads:add(dlst[2])
+          if opt.brnn == 1 then
+            encoder_bwd_grads:add(dlst[2])
+          end
+        else
+          encoder_grads[{{}, source_l}]:add(dlst[2])
+          if opt.brnn == 1 then
+            encoder_bwd_grads[{{}, 1}]:add(dlst[2])
+          end
+        end
+        drnn_state_dec[#drnn_state_dec]:zero()
+        if opt.input_feed == 1 then
+          drnn_state_dec[#drnn_state_dec]:add(dlst[3])
+        end
+        for j = dec_offset, #dlst do
+          drnn_state_dec[j-dec_offset+1]:copy(dlst[j])
+        end
+      end
+      word_vec_layers[2].gradWeight[1]:zero()
+      if opt.fix_word_vecs_dec == 1 then
+        word_vec_layers[2].gradWeight:zero()
+      end
+
+      local grad_norm = 0
+      grad_norm = grad_norm + grad_params[2]:norm()^2 + grad_params[3]:norm()^2
+
+      -- backward prop encoder
+      if opt.gpuid >= 0 and opt.gpuid2 >= 0 then
+        cutorch.setDevice(opt.gpuid)
+        local encoder_grads2 = encoder_grad_proto2[{{1, batch_l}, {1, source_l}}]
+        encoder_grads2:zero()
+        encoder_grads2:copy(encoder_grads)
+        encoder_grads = encoder_grads2 -- batch_l x source_l x rnn_size
+      end
+
+      local drnn_state_enc = reset_state(init_bwd_enc, batch_l)
+      if opt.init_dec == 1 then
+        for L = 1, opt.num_layers do
+          drnn_state_enc[L*2-1]:copy(drnn_state_dec[L*2-1])
+          drnn_state_enc[L*2]:copy(drnn_state_dec[L*2])
+        end
+      end
+
+      for t = source_l, 1, -1 do
+        local encoder_input = {source[t], table.unpack(rnn_state_enc[t-1])}
+        if opt.attn == 1 then
+          drnn_state_enc[#drnn_state_enc]:add(encoder_grads[{{},t}])
+        else
+          if t == source_l then
+            drnn_state_enc[#drnn_state_enc]:add(encoder_grads[{{},t}])
+          end
+        end
+        local dlst = encoder_clones[t]:backward(encoder_input, drnn_state_enc)
+        for j = 1, #drnn_state_enc do
+          drnn_state_enc[j]:copy(dlst[j+1])
+        end
       end
 
       if opt.brnn == 1 then
-	 local rnn_state_enc = reset_state(init_fwd_enc, batch_l)
-	 for t = source_l, 1, -1 do
-	    local encoder_input = {source[t], table.unpack(rnn_state_enc)}
-	    local out = encoder_bwd_clones[1]:forward(encoder_input)
-	    rnn_state_enc = out
-	    context[{{},t}]:add(out[#out])
-	 end
-	 if opt.init_dec == 1 then
-	    for L = 1, opt.num_layers do
-	       rnn_state_dec[L*2-1+opt.input_feed]:add(rnn_state_enc[L*2-1])
-	       rnn_state_dec[L*2+opt.input_feed]:add(rnn_state_enc[L*2])
-	    end
-	 end	 
-      end      	 	 
-      
-      local loss = 0
-      for t = 1, target_l do
-	 local decoder_input
-	 if opt.attn == 1 then
-	    decoder_input = {target[t], context, table.unpack(rnn_state_dec)}
-	 else
-	    decoder_input = {target[t], context[{{},source_l}], table.unpack(rnn_state_dec)}
-	 end	 
-	 local out = decoder_clones[1]:forward(decoder_input)
-         rnn_state_dec = {}
-	 if opt.input_feed == 1 then
-	    table.insert(rnn_state_dec, out[#out])
-	 end	 
-         for j = 1, #out-1 do
-	    table.insert(rnn_state_dec, out[j])
-	 end
-	 local pred = generator:forward(out[#out])
-	 loss = loss + criterion:forward(pred, target_out[t])
+        local drnn_state_enc = reset_state(init_bwd_enc, batch_l)
+        if opt.init_dec == 1 then
+          for L = 1, opt.num_layers do
+            drnn_state_enc[L*2-1]:copy(drnn_state_dec[L*2-1])
+            drnn_state_enc[L*2]:copy(drnn_state_dec[L*2])
+          end
+        end
+        for t = 1, source_l do
+          local encoder_input = {source[t], table.unpack(rnn_state_enc_bwd[t+1])}
+          if opt.attn == 1 then
+            drnn_state_enc[#drnn_state_enc]:add(encoder_bwd_grads[{{},t}])
+          else
+            if t == 1 then
+              drnn_state_enc[#drnn_state_enc]:add(encoder_bwd_grads[{{},t}])
+            end
+          end
+          local dlst = encoder_bwd_clones[t]:backward(encoder_input, drnn_state_enc)
+          for j = 1, #drnn_state_enc do
+            drnn_state_enc[j]:copy(dlst[j+1])
+          end
+        end
       end
-      nll = nll + loss
-      total = total + nonzeros
-   end
-   local valid = math.exp(nll / total)
-   print("Valid", valid)
-   collectgarbage()
-   return valid
+
+      word_vec_layers[1].gradWeight[1]:zero()
+      if opt.fix_word_vecs_enc == 1 then
+        word_vec_layers[1].gradWeight:zero()
+      end
+
+      grad_norm = grad_norm + grad_params[1]:norm()^2
+      if opt.brnn == 1 then
+        grad_norm = grad_norm + grad_params[4]:norm()^2
+      end
+      grad_norm = grad_norm^0.5
+      if opt.brnn == 1 then
+        word_vec_layers[1].gradWeight:add(word_vec_layers[3].gradWeight)
+        if opt.use_chars_enc == 1 then
+          for j = 1, charcnn_offset do
+            charcnn_grad_layers[j]:add(charcnn_grad_layers[j+charcnn_offset])
+          end
+        end
+      end
+      -- Shrink norm and update params
+      local param_norm = 0
+      local shrinkage = opt.max_grad_norm / grad_norm
+      for j = 1, #grad_params do
+        if opt.gpuid >= 0 and opt.gpuid2 >= 0 then
+          if j == 1 then
+            cutorch.setDevice(opt.gpuid)
+          else
+            cutorch.setDevice(opt.gpuid2)
+          end
+        end
+        if shrinkage < 1 then
+          grad_params[j]:mul(shrinkage)
+        end
+        if opt.optim == 'adagrad' then
+          adagrad_step(params[j], grad_params[j], layer_etas[j], optStates[j])
+        elseif opt.optim == 'adadelta' then
+          adadelta_step(params[j], grad_params[j], layer_etas[j], optStates[j])
+        elseif opt.optim == 'adam' then
+          adam_step(params[j], grad_params[j], layer_etas[j], optStates[j])
+        else
+          params[j]:add(grad_params[j]:mul(-opt.learning_rate))
+        end
+        param_norm = param_norm + params[j]:norm()^2
+      end
+      param_norm = param_norm^0.5
+      if opt.brnn == 1 then
+        word_vec_layers[3].weight:copy(word_vec_layers[1].weight)
+        if opt.use_chars_enc == 1 then
+          for j = 1, charcnn_offset do
+            charcnn_layers[j+charcnn_offset]:copy(charcnn_layers[j])
+          end
+        end
+      end
+
+      -- Bookkeeping
+      num_words_target = num_words_target + batch_l*target_l
+      num_words_source = num_words_source + batch_l*source_l
+      train_nonzeros = train_nonzeros + nonzeros
+      train_loss = train_loss + loss*batch_l
+      local time_taken = timer:time().real - start_time
+      if i % opt.print_every == 0 then
+        local stats = string.format('Epoch: %d, Batch: %d/%d, Batch size: %d, LR: %.4f, ',
+          epoch, i, data:size(), batch_l, opt.learning_rate)
+        stats = stats .. string.format('PPL: %.2f, |Param|: %.2f, |GParam|: %.2f, ',
+          math.exp(train_loss/train_nonzeros), param_norm, grad_norm)
+        stats = stats .. string.format('Training: %d/%d/%d total/source/target tokens/sec',
+          (num_words_target+num_words_source) / time_taken,
+          num_words_source / time_taken,
+          num_words_target / time_taken)
+        print(stats)
+      end
+      if i % 200 == 0 then
+        collectgarbage()
+      end
+    end
+    return train_loss, train_nonzeros
+  end
+
+  local total_loss, total_nonzeros, batch_loss, batch_nonzeros
+  for epoch = opt.start_epoch, opt.epochs do
+    generator:training()
+    if opt.num_shards > 0 then
+      total_loss = 0
+      total_nonzeros = 0
+      local shard_order = torch.randperm(opt.num_shards)
+      for s = 1, opt.num_shards do
+        local fn = train_data .. '.' .. shard_order[s] .. '.hdf5'
+        print('loading shard #' .. shard_order[s])
+        local shard_data = data.new(opt, fn)
+        batch_loss, batch_nonzeros = train_batch(shard_data, epoch)
+        total_loss = total_loss + batch_loss
+        total_nonzeros = total_nonzeros + batch_nonzeros
+      end
+    else
+      total_loss, total_nonzeros = train_batch(train_data, epoch)
+    end
+    local train_score = math.exp(total_loss/total_nonzeros)
+    print('Train', train_score)
+    opt.train_perf[#opt.train_perf + 1] = train_score
+    local score = eval(valid_data)
+    opt.val_perf[#opt.val_perf + 1] = score
+    if opt.optim == 'sgd' then --only decay with SGD
+      decay_lr(epoch)
+    end
+    -- clean and save models
+    local savefile = string.format('%s_epoch%.2f_%.2f.t7', opt.savefile, epoch, score)
+    if epoch % opt.save_every == 0 then
+      print('saving checkpoint to ' .. savefile)
+      clean_layer(generator)
+      if opt.brnn == 0 then
+        torch.save(savefile, {{encoder, decoder, generator}, opt})
+      else
+        torch.save(savefile, {{encoder, decoder, generator, encoder_bwd}, opt})
+      end
+    end
+  end
+  -- save final model
+  local savefile = string.format('%s_final.t7', opt.savefile)
+  clean_layer(generator)
+  print('saving final model to ' .. savefile)
+  if opt.brnn == 0 then
+    torch.save(savefile, {{encoder:double(), decoder:double(), generator:double()}, opt})
+  else
+    torch.save(savefile, {{encoder:double(), decoder:double(), generator:double(),
+          encoder_bwd:double()}, opt})
+  end
 end
 
+function eval(data)
+  encoder_clones[1]:evaluate()
+  decoder_clones[1]:evaluate() -- just need one clone
+  generator:evaluate()
+  if opt.brnn == 1 then
+    encoder_bwd_clones[1]:evaluate()
+  end
+
+  local nll = 0
+  local total = 0
+  for i = 1, data:size() do
+    local d = data[i]
+    local target, target_out, nonzeros, source = d[1], d[2], d[3], d[4]
+    local batch_l, target_l, source_l = d[5], d[6], d[7]
+    if opt.gpuid >= 0 and opt.gpuid2 >= 0 then
+      cutorch.setDevice(opt.gpuid)
+    end
+    local rnn_state_enc = reset_state(init_fwd_enc, batch_l)
+    local context = context_proto[{{1, batch_l}, {1, source_l}}]
+    -- forward prop encoder
+    for t = 1, source_l do
+      local encoder_input = {source[t], table.unpack(rnn_state_enc)}
+      local out = encoder_clones[1]:forward(encoder_input)
+      rnn_state_enc = out
+      context[{{},t}]:copy(out[#out])
+    end
+
+    if opt.gpuid >= 0 and opt.gpuid2 >= 0 then
+      cutorch.setDevice(opt.gpuid2)
+      local context2 = context_proto2[{{1, batch_l}, {1, source_l}}]
+      context2:copy(context)
+      context = context2
+    end
+
+    local rnn_state_dec = reset_state(init_fwd_dec, batch_l)
+    if opt.init_dec == 1 then
+      for L = 1, opt.num_layers do
+        rnn_state_dec[L*2-1+opt.input_feed]:copy(rnn_state_enc[L*2-1])
+        rnn_state_dec[L*2+opt.input_feed]:copy(rnn_state_enc[L*2])
+      end
+    end
+
+    if opt.brnn == 1 then
+      local rnn_state_enc = reset_state(init_fwd_enc, batch_l)
+      for t = source_l, 1, -1 do
+        local encoder_input = {source[t], table.unpack(rnn_state_enc)}
+        local out = encoder_bwd_clones[1]:forward(encoder_input)
+        rnn_state_enc = out
+        context[{{},t}]:add(out[#out])
+      end
+      if opt.init_dec == 1 then
+        for L = 1, opt.num_layers do
+          rnn_state_dec[L*2-1+opt.input_feed]:add(rnn_state_enc[L*2-1])
+          rnn_state_dec[L*2+opt.input_feed]:add(rnn_state_enc[L*2])
+        end
+      end
+    end
+
+    local loss = 0
+    for t = 1, target_l do
+      local decoder_input
+      if opt.attn == 1 then
+        decoder_input = {target[t], context, table.unpack(rnn_state_dec)}
+      else
+        decoder_input = {target[t], context[{{},source_l}], table.unpack(rnn_state_dec)}
+      end
+      local out = decoder_clones[1]:forward(decoder_input)
+      rnn_state_dec = {}
+      if opt.input_feed == 1 then
+        table.insert(rnn_state_dec, out[#out])
+      end
+      for j = 1, #out-1 do
+        table.insert(rnn_state_dec, out[j])
+      end
+      local pred = generator:forward(out[#out])
+      loss = loss + criterion:forward(pred, target_out[t])
+    end
+    nll = nll + loss
+    total = total + nonzeros
+  end
+  local valid = math.exp(nll / total)
+  print("Valid", valid)
+  collectgarbage()
+  return valid
+end
 
 function get_layer(layer)
-   if layer.name ~= nil then
-      if layer.name == 'word_vecs_dec' then
-	 table.insert(word_vec_layers, layer)
-      elseif layer.name == 'word_vecs_enc' then
-	 table.insert(word_vec_layers, layer)
-      elseif layer.name == 'charcnn_enc' or layer.name == 'mlp_enc' then
-	 local p, gp = layer:parameters()
-	 for i = 1, #p do
-	    table.insert(charcnn_layers, p[i])
-	    table.insert(charcnn_grad_layers, gp[i])
-	 end	 
+  if layer.name ~= nil then
+    if layer.name == 'word_vecs_dec' then
+      table.insert(word_vec_layers, layer)
+    elseif layer.name == 'word_vecs_enc' then
+      table.insert(word_vec_layers, layer)
+    elseif layer.name == 'charcnn_enc' or layer.name == 'mlp_enc' then
+      local p, gp = layer:parameters()
+      for i = 1, #p do
+        table.insert(charcnn_layers, p[i])
+        table.insert(charcnn_grad_layers, gp[i])
       end
-   end
+    end
+  end
 end
 
-function main() 
-    -- parse input params
-   opt = cmd:parse(arg)
-   if opt.gpuid >= 0 then
-      print('using CUDA on GPU ' .. opt.gpuid .. '...')
-      if opt.gpuid2 >= 0 then
-	 print('using CUDA on second GPU ' .. opt.gpuid2 .. '...')
-      end      
-      require 'cutorch'
-      require 'cunn'
-      if opt.cudnn == 1 then
-	 print('loading cudnn...')
-	 require 'cudnn'
-      end      
-      cutorch.setDevice(opt.gpuid)
-      cutorch.manualSeed(opt.seed)      
-   end
-   
-   -- Create the data loader class.
-   print('loading data...')
-   if opt.num_shards == 0 then
-      train_data = data.new(opt, opt.data_file)
-   else
-      train_data = opt.data_file
-   end
-   
-   valid_data = data.new(opt, opt.val_data_file)
-   print('done!')
-   print(string.format('Source vocab size: %d, Target vocab size: %d',
-		       valid_data.source_size, valid_data.target_size))   
-   opt.max_sent_l_src = valid_data.source:size(2)
-   opt.max_sent_l_targ = valid_data.target:size(2)
-   opt.max_sent_l = math.max(opt.max_sent_l_src, opt.max_sent_l_targ)
-   if opt.max_batch_l == '' then
-      opt.max_batch_l = valid_data.batch_l:max()
-   end
-   
-   if opt.use_chars_enc == 1 or opt.use_chars_dec == 1 then
-      opt.max_word_l = valid_data.char_length
-   end
-   print(string.format('Source max sent len: %d, Target max sent len: %d',
-		       valid_data.source:size(2), valid_data.target:size(2)))   
-   
-   -- Build model
-   if opt.train_from:len() == 0 then
-      encoder = make_lstm(valid_data, opt, 'enc', opt.use_chars_enc)
-      decoder = make_lstm(valid_data, opt, 'dec', opt.use_chars_dec)
-      generator, criterion = make_generator(valid_data, opt)
-      if opt.brnn == 1 then
-	 encoder_bwd = make_lstm(valid_data, opt, 'enc', opt.use_chars_enc)
-      end      
-   else
-      assert(path.exists(opt.train_from), 'checkpoint path invalid')
-      print('loading ' .. opt.train_from .. '...')
-      local checkpoint = torch.load(opt.train_from)
-      local model, model_opt = checkpoint[1], checkpoint[2]
-      opt.num_layers = model_opt.num_layers
-      opt.rnn_size = model_opt.rnn_size
-      opt.input_feed = model_opt.input_feed
-      opt.attn = model_opt.attn
-      opt.brnn = model_opt.brnn
-      encoder = model[1]:double()
-      decoder = model[2]:double()      
-      generator = model[3]:double()
-      if model_opt.brnn == 1 then
-	 encoder_bwd = model[4]:double()
-      end      
-      _, criterion = make_generator(valid_data, opt)
-   end   
-   
-   layers = {encoder, decoder, generator}
-   if opt.brnn == 1 then
-      table.insert(layers, encoder_bwd)
-   end
+function main()
+  -- parse input params
+  opt = cmd:parse(arg)
 
-   if opt.optim ~= 'sgd' then
-      layer_etas = {}
-      optStates = {}
-      for i = 1, #layers do
-	 layer_etas[i] = opt.learning_rate -- can have layer-specific lr, if desired
-	 optStates[i] = {}
-      end     
-   end
-   
-   if opt.gpuid >= 0 then
-      for i = 1, #layers do	 
-	 if opt.gpuid2 >= 0 then 
-	    if i == 1 or i == 4 then
-	       cutorch.setDevice(opt.gpuid) --encoder on gpu1
-	    else
-	       cutorch.setDevice(opt.gpuid2) --decoder/generator on gpu2
-	    end
-	 end
-	 layers[i]:cuda()
+  torch.manualSeed(opt.seed)
+
+  if opt.gpuid >= 0 then
+    print('using CUDA on GPU ' .. opt.gpuid .. '...')
+    if opt.gpuid2 >= 0 then
+      print('using CUDA on second GPU ' .. opt.gpuid2 .. '...')
+    end
+    require 'cutorch'
+    require 'cunn'
+    if opt.cudnn == 1 then
+      print('loading cudnn...')
+      require 'cudnn'
+    end
+    cutorch.setDevice(opt.gpuid)
+    cutorch.manualSeed(opt.seed)
+  end
+
+  -- Create the data loader class.
+  print('loading data...')
+  if opt.num_shards == 0 then
+    train_data = data.new(opt, opt.data_file)
+  else
+    train_data = opt.data_file
+  end
+
+  valid_data = data.new(opt, opt.val_data_file)
+  print('done!')
+  print(string.format('Source vocab size: %d, Target vocab size: %d',
+      valid_data.source_size, valid_data.target_size))
+  opt.max_sent_l_src = valid_data.source:size(2)
+  opt.max_sent_l_targ = valid_data.target:size(2)
+  opt.max_sent_l = math.max(opt.max_sent_l_src, opt.max_sent_l_targ)
+  if opt.max_batch_l == '' then
+    opt.max_batch_l = valid_data.batch_l:max()
+  end
+
+  if opt.use_chars_enc == 1 or opt.use_chars_dec == 1 then
+    opt.max_word_l = valid_data.char_length
+  end
+  print(string.format('Source max sent len: %d, Target max sent len: %d',
+      valid_data.source:size(2), valid_data.target:size(2)))
+
+  -- Build model
+  if opt.train_from:len() == 0 then
+    encoder = make_lstm(valid_data, opt, 'enc', opt.use_chars_enc)
+    decoder = make_lstm(valid_data, opt, 'dec', opt.use_chars_dec)
+    generator, criterion = make_generator(valid_data, opt)
+    if opt.brnn == 1 then
+      encoder_bwd = make_lstm(valid_data, opt, 'enc', opt.use_chars_enc)
+    end
+  else
+    assert(path.exists(opt.train_from), 'checkpoint path invalid')
+    print('loading ' .. opt.train_from .. '...')
+    local checkpoint = torch.load(opt.train_from)
+    local model, model_opt = checkpoint[1], checkpoint[2]
+    opt.num_layers = model_opt.num_layers
+    opt.rnn_size = model_opt.rnn_size
+    opt.input_feed = model_opt.input_feed
+    opt.attn = model_opt.attn
+    opt.brnn = model_opt.brnn
+    encoder = model[1]:double()
+    decoder = model[2]:double()
+    generator = model[3]:double()
+    if model_opt.brnn == 1 then
+      encoder_bwd = model[4]:double()
+    end
+    _, criterion = make_generator(valid_data, opt)
+  end
+
+  layers = {encoder, decoder, generator}
+  if opt.brnn == 1 then
+    table.insert(layers, encoder_bwd)
+  end
+
+  if opt.optim ~= 'sgd' then
+    layer_etas = {}
+    optStates = {}
+    for i = 1, #layers do
+      layer_etas[i] = opt.learning_rate -- can have layer-specific lr, if desired
+      optStates[i] = {}
+    end
+  end
+
+  if opt.gpuid >= 0 then
+    for i = 1, #layers do
+      if opt.gpuid2 >= 0 then
+        if i == 1 or i == 4 then
+          cutorch.setDevice(opt.gpuid) --encoder on gpu1
+        else
+          cutorch.setDevice(opt.gpuid2) --decoder/generator on gpu2
+        end
       end
-      if opt.gpuid2 >= 0 then
-	 cutorch.setDevice(opt.gpuid2) --criterion on gpu2
-      end      
-      criterion:cuda()      
-   end
+      layers[i]:cuda()
+    end
+    if opt.gpuid2 >= 0 then
+      cutorch.setDevice(opt.gpuid2) --criterion on gpu2
+    end
+    criterion:cuda()
+  end
 
-   -- these layers will be manipulated during training
-   word_vec_layers = {}
-   if opt.use_chars_enc == 1 then
-      charcnn_layers = {}
-      charcnn_grad_layers = {}
-   end
-   encoder:apply(get_layer)   
-   decoder:apply(get_layer)
-   if opt.brnn == 1 then
-      if opt.use_chars_enc == 1 then
-	 charcnn_offset = #charcnn_layers
-      end      
-      encoder_bwd:apply(get_layer)
-   end   
-   train(train_data, valid_data)
+  -- these layers will be manipulated during training
+  word_vec_layers = {}
+  if opt.use_chars_enc == 1 then
+    charcnn_layers = {}
+    charcnn_grad_layers = {}
+  end
+  encoder:apply(get_layer)
+  decoder:apply(get_layer)
+  if opt.brnn == 1 then
+    if opt.use_chars_enc == 1 then
+      charcnn_offset = #charcnn_layers
+    end
+    encoder_bwd:apply(get_layer)
+  end
+  train(train_data, valid_data)
 end
 
 main()

--- a/train.lua
+++ b/train.lua
@@ -2,10 +2,9 @@ require 'nn'
 require 'nngraph'
 require 'hdf5'
 
-require 'data'
-require 'util'
-require 'models'
-require 'model_utils'
+dofile 'data.lua'
+dofile 'models.lua'
+dofile 'model_utils.lua'
 
 cmd = torch.CmdLine()
 

--- a/util.lua
+++ b/util.lua
@@ -2,60 +2,60 @@
 local LinearNoBias, Linear = torch.class('nn.LinearNoBias', 'nn.Linear')
 
 function LinearNoBias:__init(inputSize, outputSize)
-   nn.Module.__init(self)
+  nn.Module.__init(self)
 
-   self.weight = torch.Tensor(outputSize, inputSize)
-   self.gradWeight = torch.Tensor(outputSize, inputSize)
+  self.weight = torch.Tensor(outputSize, inputSize)
+  self.gradWeight = torch.Tensor(outputSize, inputSize)
 
-   self:reset()
+  self:reset()
 end
 
 function LinearNoBias:reset(stdv)
-   if stdv then
-      stdv = stdv * math.sqrt(3)
-   else
-      stdv = 1./math.sqrt(self.weight:size(2))
-   end
-   if nn.oldSeed then
-      for i=1,self.weight:size(1) do
-         self.weight:select(1, i):apply(function()
-            return torch.uniform(-stdv, stdv)
-         end)
-      end
-   else
-      self.weight:uniform(-stdv, stdv)
-   end
+  if stdv then
+    stdv = stdv * math.sqrt(3)
+  else
+    stdv = 1./math.sqrt(self.weight:size(2))
+  end
+  if nn.oldSeed then
+    for i=1,self.weight:size(1) do
+      self.weight:select(1, i):apply(function()
+          return torch.uniform(-stdv, stdv)
+        end)
+    end
+  else
+    self.weight:uniform(-stdv, stdv)
+  end
 
-   return self
+  return self
 end
 
 function LinearNoBias:updateOutput(input)
-   if input:dim() == 1 then
-      self.output:resize(self.weight:size(1))
-      self.output:mv(self.weight, input)
-   elseif input:dim() == 2 then
-      local nframe = input:size(1)
-      local nElement = self.output:nElement()
-      self.output:resize(nframe, self.weight:size(1))
-      if self.output:nElement() ~= nElement then
-         self.output:zero()
-      end
-      if not self.addBuffer or self.addBuffer:nElement() ~= nframe then
-         self.addBuffer = input.new(nframe):fill(1)
-      end
-      self.output:addmm(0, self.output, 1, input, self.weight:t())
-   else
-      error('input must be vector or matrix')
-   end
+  if input:dim() == 1 then
+    self.output:resize(self.weight:size(1))
+    self.output:mv(self.weight, input)
+  elseif input:dim() == 2 then
+    local nframe = input:size(1)
+    local nElement = self.output:nElement()
+    self.output:resize(nframe, self.weight:size(1))
+    if self.output:nElement() ~= nElement then
+      self.output:zero()
+    end
+    if not self.addBuffer or self.addBuffer:nElement() ~= nframe then
+      self.addBuffer = input.new(nframe):fill(1)
+    end
+    self.output:addmm(0, self.output, 1, input, self.weight:t())
+  else
+    error('input must be vector or matrix')
+  end
 
-   return self.output
+  return self.output
 end
 
 function LinearNoBias:accGradParameters(input, gradOutput, scale)
-   scale = scale or 1
-   if input:dim() == 1 then
-      self.gradWeight:addr(scale, gradOutput, input)
-   elseif input:dim() == 2 then
-      self.gradWeight:addmm(scale, gradOutput:t(), input)
-   end
+  scale = scale or 1
+  if input:dim() == 1 then
+    self.gradWeight:addr(scale, gradOutput, input)
+  elseif input:dim() == 2 then
+    self.gradWeight:addmm(scale, gradOutput:t(), input)
+  end
 end


### PR DESCRIPTION
Hi Yoon,

I did a little cleanup of your lua scripts.
We plan to add new features to seq2seq-attn and use it in our translation engines, and It's important for us to start with a clean code base.
The current inconsistencies make the code unusable in a team environment and it would be great if you could integrate this. Otherwise, we won't be able to merge future upstream changes easily.

The patch is really big because basically all lines have been changed so let me know if there is anything unclear.

Patch details:

- remove redundant options parsing (cmd:parse was unnecessary called twice in several scripts)

- cleanup requires (remove unused, add missing, harmonize call style)
  The code was executing just fine when using the torch interactive interpreter (th command) that makes an extra effort to find lua scripts, but not with the lua interpreter.
  For example, the dot in a require instruction (eg: 'script.lua') is used as a path separator in lua.
  That means lua will try to find a script named 'lua.lua' located in the 'script' subdir, which is obvisouly not what you intended.

- cleanup trailing whitespaces

- cleanup mixed indentation: 2 spaces, no tabs
  Before this, the indentation was a mix of 1/2/3 spaces and tabs that made the code unreadable depending on which text editor you used). It would help to keep this rule from now on.