### PR TITLE
Feature/guidedalignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ will ignore the `srcvocabsize,targetvocabsize`.
 * `unkfilter`: Ignore sentences with too many UNK tokens. Can be an absolute count limit (if > 1)
 or a proportional limit (0 < unkfilter < 1).
 * `shuffle`: Shuffle sentences.
+* `alignfile`, `alignvalfile`: If provided with filenames that contain 'Pharaoh' format alignment
+on the train and validation data, source-to-target alignments are stored in the dataset.
 
 #### Training options (`train.lua`)
 **Data options**
@@ -147,6 +149,11 @@ Below options only apply if using the character model.
 * `kernel_width`: Size (i.e. width) of the convolutional filter.
 * `num_kernels`: Number of convolutional filters (feature maps). So the representation from characters will have this many dimensions.
 * `num_highway_layers`: Number of highway layers in the character composition model.
+
+To build a model with guided alignment (implemented similarly to [Guided Alignment Training for Topic-Aware Neural Machine Translation](https://arxiv.org/abs/1607.01628) (Chen et al. 2016)):
+* `guided_alignment`: If 1, use external alignments to guide the attention weights
+* `guided_alignment_weight`: weight for guided alignment criterion
+* `guided_alignment_decay`: decay rate per epoch for alignment weight
 
 **Optimization options**
 

--- a/s2sa/models.lua
+++ b/s2sa/models.lua
@@ -141,10 +141,15 @@ function make_lstm(data, opt, model, use_chars)
   if model == 'dec' then
     local top_h = outputs[#outputs]
     local decoder_out
+    local attn_output
     if opt.attn == 1 then
       local decoder_attn = make_decoder_attn(data, opt)
       decoder_attn.name = 'decoder_attn'
-      decoder_out = decoder_attn({top_h, inputs[2]})
+      if opt.guided_alignment == 1 then
+        decoder_out, attn_output = decoder_attn({top_h, inputs[2]}):split(2)
+      else
+        decoder_out = decoder_attn({top_h, inputs[2]})
+      end
     else
       decoder_out = nn.JoinTable(2)({top_h, inputs[2]})
       decoder_out = nn.Tanh()(nn.LinearNoBias(opt.rnn_size*2, opt.rnn_size)(decoder_out))
@@ -154,6 +159,9 @@ function make_lstm(data, opt, model, use_chars)
                                                    (decoder_out)
     end
     table.insert(outputs, decoder_out)
+    if opt.guided_alignment == 1 then
+      table.insert(outputs, attn_output)
+    end
   end
   return nn.gModule(inputs, outputs)
 end
@@ -178,6 +186,10 @@ function make_decoder_attn(data, opt, simple)
   local softmax_attn = nn.SoftMax()
   softmax_attn.name = 'softmax_attn'
   attn = softmax_attn(attn)
+  local attn_output
+  if opt.guided_alignment == 1 then
+    attn_output = attn
+  end
   attn = nn.Replicate(1,2)(attn) -- batch_l x 1 x source_l
 
   -- apply attention to context
@@ -203,7 +215,11 @@ function make_decoder_attn(data, opt, simple)
                                                 {{opt.max_batch_l, opt.rnn_size}, {opt.max_batch_l, opt.rnn_size}})
                                    ({context_combined,inputs[1]})
   end
-  return nn.gModule(inputs, {context_output})
+  if opt.guided_alignment == 1 then
+    return nn.gModule(inputs, {context_output, attn_output})
+  else
+    return nn.gModule(inputs, {context_output})
+  end
 end
 
 function make_generator(data, opt)


### PR DESCRIPTION
This request adds the implementation of the guided alignment as described in [Guided Alignment Training for Topic-Aware Neural Machine Translation](https://arxiv.org/abs/1607.01628) (Chen et al. 2016)

In summary:
- preprocess.py: optionally stores source-to-target alignments in parse format (-alignfile, -alignvalfile)
- s2sa/data.lua: if present, loads the alignments and converts them into dense format per batch  
- train.py: optionally creates a parallel criterion consisting of the decoder criterion (ClassNLLCriterion) with the criterion for guided alignment (MSECriterion) (--guided_alignment, --guided_alignment_weight, --guided_alignment_decay)
- s2sa/models.lua: optionally exposes attention output in the decoder model

