### PR TITLE
Disable CUDA cross-GPU checks when 2 GPUs are used

### DIFF
--- a/train.lua
+++ b/train.lua
@@ -951,6 +951,8 @@ function main()
     print('using CUDA on GPU ' .. opt.gpuid .. '...')
     if opt.gpuid2 >= 0 then
       print('using CUDA on second GPU ' .. opt.gpuid2 .. '...')
+      -- Disable cross-GPU checks
+      cutorch.setKernelPeerToPeerAccess(true)
     end
     require 'cutorch'
     require 'cunn'


### PR DESCRIPTION
Fixes the following error when training on two GPUs:

> Assertion `THCTensor_(checkGPU)(state, 3, self_, src1, src2)'

Solution found here: https://github.com/torch/cutorch/issues/434#issuecomment-237281807