### PR TITLE
Add nil check to avoid 'table index is nil' errors

### DIFF
--- a/s2sa/beam.lua
+++ b/s2sa/beam.lua
@@ -414,7 +414,10 @@ function idx2key(file)
     for w in line:gmatch'([^%s]+)' do
       table.insert(c, w)
     end
-    t[tonumber(c[2])] = c[1]
+    t_index = tonumber(c[2])
+    if t_index ~= nil then
+       t[t_index] = c[1]
+    end
   end
   return t
 end

--- a/s2sa/extract_states.lua
+++ b/s2sa/extract_states.lua
@@ -229,7 +229,10 @@ function idx2key(file)
         for w in line:gmatch '([^%s]+)' do
             table.insert(c, w)
         end
-        t[tonumber(c[2])] = c[1]
+	t_index = tonumber(c[2])
+	if t_index ~= nil then
+           t[t_index] = c[1]
+	end
     end
     return t
 end


### PR DESCRIPTION
Do you see a better way to do this without nil checks each time?